### PR TITLE
Bugfix/implement correct association between regions and tours

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -5,7 +5,7 @@
 #
 class Region < ApplicationRecord
   has_one :event_record
-  has_many :tours
+  has_and_belongs_to_many :tours
   has_many :locations
 end
 

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -6,7 +6,7 @@
 #
 class Tour < Attraction
   has_many :geometry_tour_data, as: :geo_locateable, class_name: "GeoLocation"
-  has_many :regions, as: :regionable
+  has_and_belongs_to_many :regions
   enum means_of_transportation: { bike: 0, canoe: 1, foot: 2 }
 end
 

--- a/db/migrate/20190514110846_create_attractions_regions.rb
+++ b/db/migrate/20190514110846_create_attractions_regions.rb
@@ -1,0 +1,8 @@
+class CreateAttractionsRegions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :attractions_regions do |t|
+      t.references :region, index: true
+      t.references :attraction, index: true
+    end
+  end
+end

--- a/db/migrate/20190514110846_create_region_tours.rb
+++ b/db/migrate/20190514110846_create_region_tours.rb
@@ -1,0 +1,8 @@
+class CreateRegionTours < ActiveRecord::Migration[5.2]
+  def change
+    create_table :region_tours do |t|
+      t.references :region, index: true
+      t.references :tour, index: true
+    end
+  end
+end

--- a/db/migrate/20190514110846_create_region_tours.rb
+++ b/db/migrate/20190514110846_create_region_tours.rb
@@ -1,8 +1,0 @@
-class CreateRegionTours < ActiveRecord::Migration[5.2]
-  def change
-    create_table :region_tours do |t|
-      t.references :region, index: true
-      t.references :tour, index: true
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,6 +57,13 @@ ActiveRecord::Schema.define(version: 2019_05_14_110846) do
     t.index ["certificate_id"], name: "index_attractions_certificates_on_certificate_id"
   end
 
+  create_table "attractions_regions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "region_id"
+    t.bigint "attraction_id"
+    t.index ["attraction_id"], name: "index_attractions_regions_on_attraction_id"
+    t.index ["region_id"], name: "index_attractions_regions_on_region_id"
+  end
+
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.integer "tmb_id"
@@ -227,13 +234,6 @@ ActiveRecord::Schema.define(version: 2019_05_14_110846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["priceable_type", "priceable_id"], name: "index_prices_on_priceable_type_and_priceable_id"
-  end
-
-  create_table "region_tours", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "region_id"
-    t.bigint "tour_id"
-    t.index ["region_id"], name: "index_region_tours_on_region_id"
-    t.index ["tour_id"], name: "index_region_tours_on_tour_id"
   end
 
   create_table "regions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_09_081955) do
+ActiveRecord::Schema.define(version: 2019_05_14_110846) do
 
   create_table "accessibilty_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "description"
@@ -227,6 +227,13 @@ ActiveRecord::Schema.define(version: 2019_05_09_081955) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["priceable_type", "priceable_id"], name: "index_prices_on_priceable_type_and_priceable_id"
+  end
+
+  create_table "region_tours", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "region_id"
+    t.bigint "tour_id"
+    t.index ["region_id"], name: "index_region_tours_on_region_id"
+    t.index ["tour_id"], name: "index_region_tours_on_tour_id"
   end
 
   create_table "regions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Region, type: :model do
   it { is_expected.to have_many(:locations) }
+  it { is_expected.to have_and_belong_to_many(:tours) }
 end
 
 # == Schema Information


### PR DESCRIPTION

Update Association between tour and region

* before, one tour had a "has_many regions" association and a region had a "has_many tours" association. This is wrong
* to implement a relation like this both models need Active Record class method has_and_belongs_to_many
* cvreate joined table via migration
* a joined table is enough
* a joined model is not necessary  because it provides functionality which is not needed here. For further information:  https://guides.rubyonrails.org/association_basics.html#

Correct Migration and recreate database

* tour is not a table but a type of table attraction so joined table needs to be named attractions_regions