### PR TITLE
Disable CSRF TOKEN validation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session
 end


### PR DESCRIPTION
*  to make the mobile app communicate with the API endpoint for GraphQL we need to turn off CSRF token validation.