### PR TITLE
Create GraphQL query for public html files

### DIFF
--- a/app/graphql/types/public_html_file_type.rb
+++ b/app/graphql/types/public_html_file_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Types
+  class PublicHtmlFileType < Types::BaseObject
+    field :name, String, null: false
+    field :content, String, null: false
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,6 +21,9 @@ module Types
     field :tour, TourType, null: false do
       argument :id, ID, required: true
     end
+    field :public_html_file, PublicHtmlFileType, null: false do
+      argument :name, String, required: true
+    end
 
     def point_of_interest(id:)
       PointOfInterest.find(id)
@@ -37,5 +40,47 @@ module Types
     def tour(id:)
       Tour.find(id)
     end
+
+    # Provide contents from html files in `public/mobile-app/contents` through GraphQL query
+    #
+    # @param [String] name the file name
+    #
+    # @return [String] the contents of the file, if it exists - otherwise ""
+    def public_html_file(name:)
+      public_contents_folder = "#{Rails.root}/public/mobile-app/contents"
+      file_type = "html"
+      file = File.join(public_contents_folder, "#{name}.#{file_type}")
+
+      if query_file?(file, public_contents_folder, file_type)
+        return { content: File.read(file).squish }
+      end
+
+      { content: "" }
+    end
+
+    private
+
+      # Provide a list of files within a folder that are whitelisted to be queried by the
+      # GraphQL Server
+      #
+      # @param [String] path the path to lookup
+      # @param [String] file_type the file type to lookup
+      #
+      # @return [Array] list of queryable files
+      def query_files_whitelist(path, file_type)
+        queryable_files = File.join(path, "*.#{file_type}")
+        Dir.glob(queryable_files)
+      end
+
+      # Is a file allowed to be queried by the GraphQL server or not?
+      #
+      # @param [String] file the file to be queried
+      # @param [String] path the path to lookup
+      # @param [String] file_type the file type to lookup
+      #
+      # @return [Boolean] true, if file is existing and included in the whitelist - otherwise false
+      def query_file?(file, path, file_type)
+        File.exist?(file) && query_files_whitelist(path, file_type).include?(file)
+      end
   end
 end

--- a/public/mobile-app/contents/impress.html
+++ b/public/mobile-app/contents/impress.html
@@ -1,0 +1,29 @@
+<h1>Impressum</h1>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>

--- a/public/mobile-app/contents/privacy.html
+++ b/public/mobile-app/contents/privacy.html
@@ -1,0 +1,29 @@
+<h1>Datenschutz</h1>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>
+
+<p>
+  Mollit qui exercitation sunt consequat elit esse exercitation aliquip ad quis ipsum. Ea labore
+  qui eu nulla sunt cupidatat consectetur et fugiat deserunt. Ad id consectetur pariatur magna minim
+  quis veniam aute quis ullamco. Velit pariatur aliqua dolore quis. Excepteur dolor consequat dolor
+  duis nulla esse ex deserunt incididunt dolore.
+</p>


### PR DESCRIPTION
- added GraphQL type PublicHtmlFileType with name and content fields
  - name is the name of the file and content is the content of the file
- added the query for `public_html_file` with a `name` attribute
- created the pubic folder `public/mobile-app/contents/`
  - added two test files in it
- provide contents for a file only if the file is existing and inside of the
  specified folder
  - this is done per building a whitelist of all html files existing in that folder
    and lookup per `include?`

resolves #55

---

| allowed | not allowed |
|---|---|
|![Bildschirmfoto 2019-05-22 um 14 12 22](https://user-images.githubusercontent.com/1942953/58173452-b631c180-7c9b-11e9-8b1a-43f8b023e805.png) | ![Bildschirmfoto 2019-05-22 um 13 52 18](https://user-images.githubusercontent.com/1942953/58173540-ef6a3180-7c9b-11e9-8cbb-ac03cc98e03d.png)|