### PR TITLE
Feature#44/create mutation for resource tour

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
-    ffi (1.11.0)
+    ffi (1.11.1)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -133,6 +133,7 @@ GEM
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     json (2.2.0)
+    kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -203,6 +204,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -301,6 +303,9 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
+    unicorn (5.5.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -351,6 +356,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/app/graphql/mutations/create_tour.rb
+++ b/app/graphql/mutations/create_tour.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateTour < BaseMutation
+    argument :name, String, required: true
+    argument :description, String, required: false
+    argument :mobile_description, String, required: false
+    argument :active, Boolean, required: false
+    argument :category_id, Integer, required: false
+    argument :addresses, [Types::AddressInput], required: false,
+                                                as: :addresses_attributes,
+                                                prepare: lambda { |addresses, _ctx|
+                                                  addresses.map(&:to_h)
+                                                }
+    argument :contact, Types::ContactInput, required: false, as: :contact_attributes,
+                                            prepare: ->(contact, _ctx) { contact.to_h }
+    argument :data_provider, Types::DataProviderInput, required: false,
+                                                       as: :data_provider_attributes,
+                                                       prepare: lambda { |data_provider, _ctx|
+                                                                  data_provider.to_h
+                                                                }
+    argument :operating_company, Types::OperatingCompanyInput, required: false,
+                                                               as: :operating_company_attributes,
+                                                               prepare:
+                                                        lambda { |operating_company, _ctx|
+                                                          operating_company.to_h
+                                                        }
+    argument :web_urls, [Types::WebUrlInput], required: false, as: :web_urls_attributes,
+                                              prepare: ->(web_urls, _ctx) { web_urls.map(&:to_h) }
+    argument :media_contents, [Types::MediaContentInput], required: false,
+                                                          as: :media_contents_attributes,
+                                                          prepare: lambda { |media_contents, _ctx|
+                                                                     media_contents.map(&:to_h)
+                                                                   }
+    argument :length_km, Integer, required: true
+    argument :means_of_transportation, String, required: false
+    argument :geometry_tour_data, [Types::GeoLocationInput], required: false,
+                                                             as: :geometry_tour_data_attributes,
+                                                             prepare: lambda { |geometry_tour_data, _ctx|
+                                                                        geometry_tour_data.map(&:to_h)
+                                                                      }
+    argument :tags, String, as: :tag_list, required: false
+
+    field :tour, Types::TourType, null: false
+
+    type Types::TourType
+
+    def resolve(**params)
+      Tour.create!(params)
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,6 +2,7 @@
 
 module Types
   class MutationType < Types::BaseObject
+    field :createTour, mutation: Mutations::CreateTour
     field :create_point_of_interest, mutation: Mutations::CreatePointOfInterest
   end
 end

--- a/app/models/geo_location.rb
+++ b/app/models/geo_location.rb
@@ -1,8 +1,10 @@
-class GeoLocation < ApplicationRecord
-    belongs_to :geo_locateable, polymorphic: true
+# frozen_string_literal: true
 
-    validates_presence_of :latitude, :longitude
-    validates :latitude, :longitude, numericality: true
+class GeoLocation < ApplicationRecord
+  belongs_to :geo_locateable, polymorphic: true
+
+  validates_presence_of :latitude, :longitude
+  validates :latitude, :longitude, numericality: true
 end
 
 # == Schema Information

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -7,6 +7,8 @@
 class Tour < Attraction
   has_many :geometry_tour_data, as: :geo_locateable, class_name: "GeoLocation"
   enum means_of_transportation: { bike: 0, canoe: 1, foot: 2 }
+
+  accepts_nested_attributes_for :geometry_tour_data
 end
 
 # == Schema Information

--- a/doc/tour_mutation_example.graphql
+++ b/doc/tour_mutation_example.graphql
@@ -1,0 +1,154 @@
+mutation {
+	createTour(
+		name: "test"
+		categoryId: 6
+		description: "Lorem ipsum dolor sit amet consectetur adipiscing"
+		active: true
+		lengthKm: 234
+		meansOfTransportation: "bike"
+		geometryTourData: [
+			{ latitude: 64.37264, longitude: 45.431234 }
+			{ latitude: 32.37264, longitude: 40.431234 }
+			{ latitude: 36.37264, longitude: 49.431234 }
+			{ latitude: 39.37264, longitude: 41.431234 }
+			{ latitude: 41.37264, longitude: 43.431234 }
+		]
+		webUrls: [
+			{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }
+			{ url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }
+		]
+		mediaContents: [
+			{
+				captionText: "Qui dolore fugit rem."
+				copyright: "Zane Marquardt"
+				contentType: "image"
+				height: 342
+				width: 215
+				sourceUrl: { url: "https://www.image.file", description: "main image" }
+			}
+			{
+				captionText: "Id molestias omnis repellat."
+				copyright: "Dr. Willard Klocko"
+				contentType: "video"
+				height: 315
+				width: 607
+			}
+			{
+				captionText: "Provident quidem sed velit."
+				copyright: "Verona Lowe"
+				contentType: "soundcloud-audio"
+				height: 348
+				width: 766
+			}
+		]
+		addresses: [
+			{
+				street: "Musterstraße"
+				addition: "Bahnhof"
+				zip: "10100"
+				city: "Berlin"
+				kind: "start"
+				geoLocation: { latitude: 64.37264, longitude: 47.9347 }
+			}
+			{ street: "Musterstraße2", addition: "Bahnhof 2", zip: "10100", city: "Berlin2", kind: "end" }
+		]
+		contact: {
+			firstName: "Tim"
+			lastName: "Test"
+			phone: "012345678"
+			email: "test@test.de"
+			fax: "09843729047"
+			webUrls: [
+				{ url: "http://www.test1.de", description: "url 1" }
+				{ url: "http://www.test2.de", description: "url 2" }
+			]
+		}
+		dataProvider: {
+			name: "Bäder Betrieb Brandenburg"
+			address: {
+				street: "Strandstraße"
+				addition: "Schwimmbad 2"
+				zip: "10100"
+				city: "Bad Belzig"
+				geoLocation: { latitude: 8123345.3726, longitude: 8723647.9347 }
+			}
+			contact: {
+				firstName: "Tim"
+				lastName: "Test"
+				phone: "012345678"
+				email: "test@test.de"
+				fax: "09843729047"
+				webUrls: [
+					{ url: "http://www.test1.de", description: "url 1" }
+					{ url: "http://www.test2.de", description: "url 2" }
+				]
+			}
+			logo: { url: "https://www.logo-url.de", description: "url that lkeads to a logo image file" }
+			description: "TMB dind die besten"
+		}
+		operatingCompany: {
+			name: "McClure, Kemmer and Brown"
+			address: {
+				zip: "25083"
+				city: "Mialand"
+				street: "Abbie Manors"
+				kind: "default"
+				geoLocation: { latitude: -7.45018, longitude: -102.279 }
+			}
+			contact: {
+				firstName: "Alonzo"
+				lastName: "Von"
+				phone: "+235 782-754-0007 x80976"
+				webUrls: { url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }
+			}
+		}
+		tags: "[swim, swam, swum]"
+	) {
+		id
+		name
+		description
+		mobileDescription
+		categoryId
+		active
+		lengthKm
+		meansOfTransportation
+		geometryTourData {
+			latitude
+			longitude
+		}
+		webUrls {
+			url
+			description
+		}
+		mediaContents {
+			contentType
+			copyright
+			captionText
+			height
+			width
+		}
+		addresses {
+			id
+			city
+			geoLocation {
+				latitude
+				longitude
+			}
+		}
+		contact {
+			firstName
+			lastName
+			phone
+			fax
+			email
+			webUrls {
+				url
+				description
+			}
+		}
+		certificates {
+			name
+		}
+		tags
+	}
+}

--- a/spec/graphql/mutations/create_tour_spec.rb
+++ b/spec/graphql/mutations/create_tour_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::CreatePointOfInterest do
+  def perform(**args)
+    Mutations::CreateTour.new(object: nil, context: {}).resolve(args)
+  end
+
+  def create_regions
+    10.times do
+      Region.create(name: Faker::Address.country)
+    end
+  end
+
+  def create_categories
+    cat_1 = Category.create(name: Faker::IndustrySegments.super_sector)
+    cat_2 = Category.create(name: Faker::IndustrySegments.sector, parent: cat_1)
+    Category.create(name: Faker::IndustrySegments.sub_sector, parent: cat_2)
+  end
+
+  it "creates a new and valid Point of interest" do
+    create_categories
+    create_regions
+    tour = perform(
+     {:name=>"test", :description=>"Lorem ipsum dolor sit amet consectetur adipiscing", :active=>true, :category_id=> Category.last.id, :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>832764.37264, :longitude=>8723647.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contact_attributes=>{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}, :data_provider_attributes=>{:name=>"Bäder Betrieb Brandenburg", :address_attributes=>{:addition=>"Schwimmbad 2", :street=>"Strandstraße", :zip=>"10100", :city=>"Bad Belzig", :geo_location_attributes=>{:latitude=>8123345.3726, :longitude=>8723647.9347}}, :contact_attributes=>{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}, :logo_attributes=>{:url=>"https://www.logo-url.de", :description=>"url that lkeads to a logo image file"}, :description=>"TMB dind die besten"}, :operating_company_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>-7.45018, :longitude=>-102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :web_urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Naturwacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :length_km=>234, :means_of_transportation=>"bike", :geometry_tour_data_attributes=>[{:latitude=>83.37264, :longitude=>23.431234}, {:latitude=>83.37264, :longitude=>23.431234}, {:latitude=>43.37264, :longitude=>63.431234}], :tag_list=>"[swim, swam, swum]"}
+    )
+    expect(tour).to be_a(Tour)
+    expect(tour).to be_valid
+  end
+end

--- a/spec/graphql/mutations/create_tour_spec.rb
+++ b/spec/graphql/mutations/create_tour_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CreatePointOfInterest do
+RSpec.describe Mutations::Tour do
   def perform(**args)
     Mutations::CreateTour.new(object: nil, context: {}).resolve(args)
   end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Contact, type: :model do
   it { is_expected.to belong_to(:contactable) }
-  it { is_expected.to have_one(:web_url) }
+  it { is_expected.to have_many(:web_urls) }
 
   describe "#email" do
     let(:valid_contact) { create(:contact, :for_operating_company) }

--- a/spec/models/point_of_interest_spec.rb
+++ b/spec/models/point_of_interest_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PointOfInterest, type: :model do
   it { is_expected.to have_many(:web_urls) }
   it { is_expected.to have_many(:opening_hours) }
   it { is_expected.to have_many(:prices) }
-  it { is_expected.to have_many(:accessibility_informations) }
+  it { is_expected.to have_one(:accessibility_information) }
   it { is_expected.to validate_presence_of(:name) }
 end
 

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Region, type: :model do
   it { is_expected.to have_many(:locations) }
-  it { is_expected.to have_and_belong_to_many(:tours) }
+  it { is_expected.to have_and_belong_to_many(:attractions) }
 end
 
 # == Schema Information


### PR DESCRIPTION

Add mutation for resource tour

* api needs to provide app with information for tours
* to import these tours from various resources the api graphql server needs a mutation for these resources
* this commit provides this mutation

#44

Add graphql example for mutation to create a tour

Add spec for create_tour mutation

 * add spec to to spec  if the resolver creates a valid Tour

#44

Correct failing specs

* models were changed in previous commits so specs needed to be corrected

#44

Correct spec for tour mutation

#44