### PR TITLE
Feature/create mutation for resource event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,14 +103,14 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
-    ffi (1.11.0)
+    ffi (1.11.1)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.7.0)
       railties
       sprockets-rails
-    graphql (1.9.4)
+    graphql (1.9.5)
     graphql-query-resolver (0.2.0)
       graphql (~> 1.0, >= 1.0.0)
     guard (2.15.0)
@@ -133,6 +133,7 @@ GEM
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     json (2.2.0)
+    kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -203,6 +204,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -301,6 +303,9 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
+    unicorn (5.5.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -351,6 +356,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: false
+
+module Mutations
+  class CreateEventRecord < BaseMutation
+    argument :parent_id, Integer, required: false
+    argument :description, String, required: false
+    argument :title, String, required: false
+    argument :dates, [Types::DateInput], required: false, required: false,
+                                         as: :dates_attributes,
+                                         prepare: ->(dates, _ctx) { dates.map(&:to_h) }
+    argument :repeat, Boolean, required: false
+    argument :repeat_duration, Types::RepeatDurationInput, required: false,
+                                                           as: :repeat_duration_attributes,
+                                                           prepare: ->(repeat_duration, _ctx) { repeat_duration.to_h }
+    argument :category_id, Integer, required: false
+    argument :region_id, Integer, required: false
+    argument :addresses, [Types::AddressInput], required: false,
+                                                as: :addresses_attributes,
+                                                prepare: lambda { |addresses, _ctx|
+                                                  addresses.map(&:to_h)
+                                                }
+    argument :location, Types::LocationInput, required: false,
+                                              as: :location_attributes,
+                                              prepare: ->(location, _ctx) { location.to_h }
+    argument :data_provider, Types::DataProviderInput, required: false,
+                                                       as: :data_provider_attributes,
+                                                       prepare: lambda { |data_provider, _ctx|
+                                                                  data_provider.to_h
+                                                                }
+    argument :contacts, [Types::ContactInput], required: false, as: :contacts_attributes,
+                                               prepare: ->(contacts, _ctx) { contacts.map(&:to_h) }
+    argument :urls, [Types::WebUrlInput], required: false, as: :urls_attributes,
+                                          prepare: ->(urls, _ctx) { urls.map(&:to_h) }
+    argument :media_contents, [Types::MediaContentInput], required: false,
+                                                          as: :media_contents_attributes,
+                                                          prepare: lambda { |media_contents, _ctx|
+                                                            media_contents.map(&:to_h)
+                                                          }
+    argument :organizer, Types::OperatingCompanyInput, required: false,
+                                                       as: :organizer_attributes,
+                                                       prepare: lambda { |organizer, _ctx|
+                                                                  organizer.to_h
+                                                                }
+    argument :price_informations, [Types::PriceInput], required: false,
+                                                       as: :price_informations_attributes,
+                                                       prepare: lambda { |price_informations, _ctx|
+                                                                  price_informations.map(&:to_h)
+                                                                }
+    argument :accessibility_information,
+             Types::AccessibilityInformationInput,
+             required: false,
+             as: :accessibility_information_attributes,
+             prepare: lambda { |accessibility_information, _ctx|
+                        accessibility_information.to_h
+                      }
+    argument :tags, [String], as: :tag_list, required: false
+
+    field :event, Types::EventRecord, null: false
+
+    type Types::EventRecordType
+
+    def resolve(**params)
+      EventRecord.create!(params)
+    end
+  end
+end

--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -11,7 +11,9 @@ module Mutations
     argument :repeat, Boolean, required: false
     argument :repeat_duration, Types::RepeatDurationInput, required: false,
                                                            as: :repeat_duration_attributes,
-                                                           prepare: ->(repeat_duration, _ctx) { repeat_duration.to_h }
+                                                           prepare: lambda { |repeat_duration, _ctx|
+                                                                      repeat_duration.to_h
+                                                                    }
     argument :category_id, Integer, required: false
     argument :region_id, Integer, required: false
     argument :addresses, [Types::AddressInput], required: false,

--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -5,7 +5,7 @@ module Mutations
     argument :parent_id, Integer, required: false
     argument :description, String, required: false
     argument :title, String, required: false
-    argument :dates, [Types::DateInput], required: false, required: false,
+    argument :dates, [Types::DateInput], required: false,
                                          as: :dates_attributes,
                                          prepare: ->(dates, _ctx) { dates.map(&:to_h) }
     argument :repeat, Boolean, required: false

--- a/app/graphql/types/date_input.rb
+++ b/app/graphql/types/date_input.rb
@@ -1,0 +1,11 @@
+module Types
+  class DateInput < BaseInputObject
+    argument :weekday, String, required: false
+    argument :date_start, String, required: false
+    argument :date_end, String, required: false
+    argument :time_start, String, required: false
+    argument :time_end, String, required: false
+    argument :time_Description, String, required: false
+    argument :use_only_time_description, Boolean, required: false
+  end
+end

--- a/app/graphql/types/date_input.rb
+++ b/app/graphql/types/date_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class DateInput < BaseInputObject
     argument :weekday, String, required: false

--- a/app/graphql/types/event_record_type.rb
+++ b/app/graphql/types/event_record_type.rb
@@ -3,7 +3,7 @@
 module Types
   class EventRecordType < Types::BaseObject
     field :id, ID, null: false
-    field :parent_id, String, null: true
+    field :parent_id, Integer, null: true
     field :description, String, null: true
     field :title, String, null: false
     field :dates, [DateType], null: false
@@ -12,6 +12,7 @@ module Types
     field :category_id, Integer, null: false
     field :addresses, [AddressType], null: false
     field :location, LocationType, null: true
+    field :region_id, String, null: true
     field :data_provider, DataProviderType, null: true
     field :contacts, [ContactType], null: true
     field :urls, [WebUrlType], null: true
@@ -19,6 +20,7 @@ module Types
     field :organizer, OperatingCompanyType, null: true
     field :price_informations, [PriceType], null: true
     field :accessibility_information, AccessibilityInformationType, null: true
+    field :tag_list, [String], null: true
     field :updated_at, String, null: true
     field :created_at, String, null: true
   end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,6 +2,7 @@
 
 module Types
   class MutationType < Types::BaseObject
+    field :create_event_record, mutation: Mutations::CreateEventRecord
     field :create_point_of_interest, mutation: Mutations::CreatePointOfInterest
   end
 end

--- a/app/graphql/types/repeat_duration_input.rb
+++ b/app/graphql/types/repeat_duration_input.rb
@@ -1,0 +1,7 @@
+module Types
+  class RepeatDurationInput < BaseInputObject
+    argument :start_date, String, required: false
+    argument :end_date, String, required: false
+    argument :every_year, Boolean, required: false
+  end
+end

--- a/app/graphql/types/repeat_duration_input.rb
+++ b/app/graphql/types/repeat_duration_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class RepeatDurationInput < BaseInputObject
     argument :start_date, String, required: false

--- a/app/graphql/types/repeat_duration_type.rb
+++ b/app/graphql/types/repeat_duration_type.rb
@@ -5,6 +5,6 @@ module Types
     field :id, ID, null: false
     field :start_date, String, null: true
     field :end_date, String, null: true
-    field :every_year, String, null: true
+    field :every_year, Boolean, null: true
   end
 end

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -2,8 +2,8 @@
 
 # this model describes the data for an event e.g. a concert or a reading.
 class EventRecord < ApplicationRecord
-  belongs_to :category
-  belongs_to :region
+  belongs_to :category, optional: true
+  belongs_to :region, optional: true
   has_many :urls, as: :web_urlable, class_name: "WebUrl"
   has_one :data_provider, as: :provideable
   has_one :organizer, as: :companyable, class_name: "OperatingCompany"
@@ -16,6 +16,10 @@ class EventRecord < ApplicationRecord
   has_one :repeat_duration
   has_many :dates, as: :dateable, class_name: "FixedDate"
 
+  accepts_nested_attributes_for :urls, :data_provider, :organizer,
+                                :addresses, :location, :contacts,
+                                :accessibility_information, :price_informations, :media_contents,
+                                :repeat_duration, :dates
   acts_as_taggable
 
   validates_presence_of :title

--- a/doc/event_record_mutation_example.graphql
+++ b/doc/event_record_mutation_example.graphql
@@ -1,0 +1,201 @@
+mutation {
+	createEventRecord(
+		title: "Test"
+		parentId: 1
+		categoryId: 5
+		regionId: 3
+		description: "Lorem ipsum dolor sit amet consectetur adipiscing"
+		dates: [
+			{
+				weekday: "Monday"
+				timeStart: "16:00"
+				timeEnd: "18:00"
+				timeDescription: "das Training findet jeden zweiten Montag im Monat statt"
+				useOnlyTimeDescription: false
+			}
+		]
+		priceInformations: [
+			{ name: "Standardkarte", amount: 5.89, groupPrice: false, description: "Tarif gilt nicht in den Ferien" }
+			{
+				name: "Familienkarte"
+				amount: 18
+				groupPrice: true
+				ageFrom: 2
+				ageTo: 17
+				minAdultCount: 10
+				maxAdultCount: 17
+				minChildrenCount: 3
+				maxChildrenCount: 9
+				description: "Tarif gilt nur in den Ferien."
+			}
+		]
+		accessibilityInformation: {
+			description: "bla"
+			types: "Tops"
+			urls: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }]
+		}
+		repeat: true
+		repeatDuration: { startDate: "0001-12-18", endDate: "0021-07-19", everyYear: true }
+		urls: [
+			{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }
+			{ url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }
+		]
+		mediaContents: [
+			{
+				captionText: "Qui dolore fugit rem."
+				copyright: "Zane Marquardt"
+				contentType: "image"
+				height: 342
+				width: 215
+				sourceUrl: { url: "https://www.image.file", description: "main image" }
+			}
+			{
+				captionText: "Id molestias omnis repellat."
+				copyright: "Dr. Willard Klocko"
+				contentType: "video"
+				height: 315
+				width: 607
+			}
+			{
+				captionText: "Provident quidem sed velit."
+				copyright: "Verona Lowe"
+				contentType: "soundcloud-audio"
+				height: 348
+				width: 766
+			}
+		]
+		addresses: [
+			{
+				street: "Musterstraße"
+				addition: "Bahnhof"
+				zip: "10100"
+				city: "Berlin"
+				kind: "start"
+				geoLocation: { latitude: 64.37264, longitude: 47.9347 }
+			}
+			{ street: "Musterstraße2", addition: "Bahnhof 2", zip: "10100", city: "Berlin2", kind: "end" }
+		]
+		contacts: [
+			{
+				firstName: "Tim"
+				lastName: "Test"
+				phone: "012345678"
+				email: "test@test.de"
+				fax: "09843729047"
+				webUrls: [
+					{ url: "http://www.test1.de", description: "url 1" }
+					{ url: "http://www.test2.de", description: "url 2" }
+				]
+			}
+		]
+		dataProvider: {
+			name: "Bäder Betrieb Brandenburg"
+			address: {
+				street: "Strandstraße"
+				addition: "Schwimmbad 2"
+				zip: "10100"
+				city: "Bad Belzig"
+				geoLocation: { latitude: 8123345.3726, longitude: 8723647.9347 }
+			}
+			contact: {
+				firstName: "Tim"
+				lastName: "Test"
+				phone: "012345678"
+				email: "test@test.de"
+				fax: "09843729047"
+				webUrls: [
+					{ url: "http://www.test1.de", description: "url 1" }
+					{ url: "http://www.test2.de", description: "url 2" }
+				]
+			}
+			logo: { url: "https://www.logo-url.de", description: "url that lkeads to a logo image file" }
+			description: "TMB dind die besten"
+		}
+		organizer: {
+			name: "McClure, Kemmer and Brown"
+			address: {
+				zip: "25083"
+				city: "Mialand"
+				street: "Abbie Manors"
+				kind: "default"
+				geoLocation: { latitude: 7.45018, longitude: 102.279 }
+			}
+			contact: {
+				firstName: "Alonzo"
+				lastName: "Von"
+				phone: "+235 782-754-0007 x80976"
+				webUrls: { url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }
+			}
+		}
+		tags: ["megaparty", "technoclassix", "underground"]
+	) {
+		id
+		title
+		categoryId
+		parentId
+		regionId
+		description
+		dates {
+			weekday
+			dateStart
+			dateEnd
+			timeStart
+			timeEnd
+			timeDescription
+			useOnlyTimeDescription
+		}
+		organizer {
+			name
+			contact {
+				firstName
+				lastName
+				phone
+				fax
+				email
+				webUrls {
+					url
+					description
+				}
+			}
+			address {
+				addition
+				street
+				zip
+				city
+				geoLocation {
+					latitude
+					longitude
+				}
+			}
+		}
+		dataProvider {
+			name
+			contact {
+				firstName
+				lastName
+				phone
+				fax
+				email
+				webUrls {
+					url
+					description
+				}
+			}
+			address {
+				addition
+				street
+				zip
+				city
+				geoLocation {
+					latitude
+					longitude
+				}
+			}
+			logo {
+				url
+				description
+			}
+		}
+		tagList
+	}
+}

--- a/spec/graphql/mutations/create_event_record_spec.rb
+++ b/spec/graphql/mutations/create_event_record_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Mutations::CreateEventRecord do
   end
 
   def create_categories
-    cat_1 = Category.create(name: Faker::IndustrySegments.super_sector)
-    cat_2 = Category.create(name: Faker::IndustrySegments.sector, parent: cat_1)
-    Category.create(name: Faker::IndustrySegments.sub_sector, parent: cat_2)
+    category_1 = Category.create(name: Faker::IndustrySegments.super_sector)
+    category_2 = Category.create(name: Faker::IndustrySegments.sector, parent: category_1)
+    Category.create(name: Faker::IndustrySegments.sub_sector, parent: category_2)
   end
 
   it "creates a new and valid Point of interest" do

--- a/spec/graphql/mutations/create_event_record_spec.rb
+++ b/spec/graphql/mutations/create_event_record_spec.rb
@@ -7,12 +7,6 @@ RSpec.describe Mutations::CreateEventRecord do
     Mutations::CreateEventRecord.new(object: nil, context: {}).resolve(args)
   end
 
-  def create_regions
-    10.times do
-      Region.create(name: Faker::Address.country)
-    end
-  end
-
   def create_categories
     category_1 = Category.create(name: Faker::IndustrySegments.super_sector)
     category_2 = Category.create(name: Faker::IndustrySegments.sector, parent: category_1)
@@ -21,7 +15,6 @@ RSpec.describe Mutations::CreateEventRecord do
 
   it "creates a new and valid Point of interest" do
     create_categories
-    create_regions
     event_record = perform(
       parent_id: 1, description: "Lorem ipsum dolor sit amet consectetur adipiscing", title: "Test", dates_attributes: [{ weekday: "Monday", time_start: "16:00", time_end: "18:00", time_description: "das Training findet jeden zweiten Montag im Monat statt", use_only_time_description: false }], repeat: true, repeat_duration_attributes: { start_date: "0001-12-18", end_date: "0021-07-19", every_year: true }, category_id: 5, region_id: 3, addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", kind: "start", geo_location_attributes: { latitude: 64.37264, longitude: 47.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2", kind: "end" }], data_provider_attributes: { name: "Bäder Betrieb Brandenburg", address_attributes: { addition: "Schwimmbad 2", street: "Strandstraße", zip: "10100", city: "Bad Belzig", geo_location_attributes: { latitude: 8_123_345.3726, longitude: 8_723_647.9347 } }, contact_attributes: { first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }, logo_attributes: { url: "https://www.logo-url.de", description: "url that lkeads to a logo image file" }, description: "TMB dind die besten" }, contacts_attributes: [{ first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }], urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], organizer_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: 7.45018, longitude: 102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, price_informations_attributes: [{ name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" }, { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["megaparty", "technoclassix", "underground"]
     )

--- a/spec/graphql/mutations/create_event_record_spec.rb
+++ b/spec/graphql/mutations/create_event_record_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::CreateEventRecord do
+  def perform(**args)
+    Mutations::CreateEventRecord.new(object: nil, context: {}).resolve(args)
+  end
+
+  def create_regions
+    10.times do
+      Region.create(name: Faker::Address.country)
+    end
+  end
+
+  def create_categories
+    cat_1 = Category.create(name: Faker::IndustrySegments.super_sector)
+    cat_2 = Category.create(name: Faker::IndustrySegments.sector, parent: cat_1)
+    Category.create(name: Faker::IndustrySegments.sub_sector, parent: cat_2)
+  end
+
+  it "creates a new and valid Point of interest" do
+    create_categories
+    create_regions
+    event_record = perform(
+      parent_id: 1, description: "Lorem ipsum dolor sit amet consectetur adipiscing", title: "Test", dates_attributes: [{ weekday: "Monday", time_start: "16:00", time_end: "18:00", time_description: "das Training findet jeden zweiten Montag im Monat statt", use_only_time_description: false }], repeat: true, repeat_duration_attributes: { start_date: "0001-12-18", end_date: "0021-07-19", every_year: true }, category_id: 5, region_id: 3, addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", kind: "start", geo_location_attributes: { latitude: 64.37264, longitude: 47.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2", kind: "end" }], data_provider_attributes: { name: "Bäder Betrieb Brandenburg", address_attributes: { addition: "Schwimmbad 2", street: "Strandstraße", zip: "10100", city: "Bad Belzig", geo_location_attributes: { latitude: 8_123_345.3726, longitude: 8_723_647.9347 } }, contact_attributes: { first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }, logo_attributes: { url: "https://www.logo-url.de", description: "url that lkeads to a logo image file" }, description: "TMB dind die besten" }, contacts_attributes: [{ first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }], urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], organizer_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: 7.45018, longitude: 102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, price_informations_attributes: [{ name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" }, { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["megaparty", "technoclassix", "underground"]
+    )
+    expect(event_record).to be_a(EventRecord)
+    expect(event_record).to be_valid
+  end
+end


### PR DESCRIPTION

Add event record mutation

* event_record mutation is necessary to import event records via the graphql api
* add necessary input types for event records
* add accepts_nested_attributes_for every has_many/has_one relation event records posseses
* this is necessary to make nested mutations  possible

#44

Spec Event Record Mutation and add example for event record mutation

#44

Update bundle 