### PR TITLE
Add validations to get rid of duplicate records

### DIFF
--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -2,6 +2,7 @@
 
 module Mutations
   class CreateEventRecord < BaseMutation
+    argument :external_id, Integer, required: false
     argument :parent_id, Integer, required: false
     argument :description, String, required: false
     argument :title, String, required: false

--- a/app/graphql/mutations/create_news_item.rb
+++ b/app/graphql/mutations/create_news_item.rb
@@ -2,6 +2,8 @@
 
 module Mutations
   class CreateNewsItem < BaseMutation
+    argument :external_id, Integer, required: false
+    argument :title, String, required: false
     argument :author, String, required: false
     argument :full_version, Boolean, required: false
     argument :characters_to_be_shown, Integer, required: false

--- a/app/graphql/mutations/create_point_of_interest.rb
+++ b/app/graphql/mutations/create_point_of_interest.rb
@@ -3,6 +3,7 @@
 module Mutations
   class CreatePointOfInterest < BaseMutation
     argument :name, String, required: true
+    argument :external_id, Integer, required: false
     argument :description, String, required: false
     argument :mobile_description, String, required: false
     argument :active, Boolean, required: false

--- a/app/graphql/mutations/create_tour.rb
+++ b/app/graphql/mutations/create_tour.rb
@@ -3,6 +3,7 @@
 module Mutations
   class CreateTour < BaseMutation
     argument :name, String, required: true
+    argument :external_id, Integer, required: false
     argument :description, String, required: false
     argument :mobile_description, String, required: false
     argument :active, Boolean, required: false

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -19,7 +19,8 @@ class Attraction < ApplicationRecord
   has_one :data_provider, as: :provideable
   has_many :web_urls, as: :web_urlable
 
-  validates_presence_of :name
+  validates_presence_of :name, uniqueness: true
+  validate :external_id, uniqueness: true, if: -> { external_id.present? }
   acts_as_taggable
 
   accepts_nested_attributes_for :web_urls, reject_if: ->(attr) { attr[:url].blank? }

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -30,6 +30,8 @@ class EventRecord < ApplicationRecord
   acts_as_taggable
 
   validates_presence_of :title
+  validate :title, uniqueness: true, if: -> { title.present? }
+  validate :external_id, uniqueness: true, if: -> { external_id.present? }
 
   def find_or_create_category
     self.category_id = Category.where(name: category_name).first_or_create.id

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -8,6 +8,10 @@ class NewsItem < ApplicationRecord
   has_one :address, as: :addressable
   has_one :source_url, as: :web_urlable, class_name: "WebUrl"
 
+  validates :title, uniqueness: true
+  validate :external_id, uniqueness: true, if: -> { external_id.present? }
+  validate :published_at, uniqueness: true, if: -> { published_at.present? }
+
   accepts_nested_attributes_for :content_blocks, :data_provider, :address, :source_url
 end
 

--- a/db/migrate/20190529153835_add_columns_to_news_item.rb
+++ b/db/migrate/20190529153835_add_columns_to_news_item.rb
@@ -1,0 +1,6 @@
+class AddColumnsToNewsItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :news_items, :external_id, :integer
+    add_column :news_items, :title, :string
+  end
+end

--- a/db/migrate/20190529160009_add_external_id_to_event_record.rb
+++ b/db/migrate/20190529160009_add_external_id_to_event_record.rb
@@ -1,0 +1,5 @@
+class AddExternalIdToEventRecord < ActiveRecord::Migration[5.2]
+  def change
+    add_column :event_records, :external_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_28_103541) do
+ActiveRecord::Schema.define(version: 2019_05_29_160009) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "description"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
     t.bigint "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "external_id"
     t.index ["category_id"], name: "index_event_records_on_category_id"
     t.index ["region_id"], name: "index_event_records_on_region_id"
   end
@@ -191,6 +192,8 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
     t.string "news_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "external_id"
+    t.string "title"
   end
 
   create_table "oauth_access_grants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION

Add attributes external_id and title to news_item

* new arguments are necessary for duplicate checks

Add external_id to event records

* necessary to avoid creation of duplicates for all main resources

Modify mutations for main resources

* modify mutations for main reosurces
* this is necessary to set new attributes external_id( all main resources) and title( only news_items) via graphql mutations

Add uniqueness validations for all main resources to avoid the creation of duplicate records