### PR TITLE
Feature/refacture data provider

### DIFF
--- a/app/controllers/data_provider_controller.rb
+++ b/app/controllers/data_provider_controller.rb
@@ -31,6 +31,9 @@ class DataProviderController < ApplicationController
 
   def update
     @data_provider.update_attributes(provider_params)
+    current_user.data_provider = @data_provider
+    current_user.save
+
     flash[:notice] = "Data Provider Updated: #{@data_provider.try(:errors).try(:full_messages)}"
     redirect_to action: :edit
   end
@@ -50,8 +53,6 @@ class DataProviderController < ApplicationController
     end
 
     def init_data_provider
-      @data_provider = DataProvider
-                         .where(provideable_type: "User", provideable_id: current_user.id)
-                         .first_or_create
+      @data_provider = current_user.data_provider || current_user.build_data_provider
     end
 end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -12,7 +12,7 @@ class GraphqlController < ApplicationController
     operation_name = params[:operationName]
     context = {
       # Query context goes here, for example:
-      # current_user: current_user,
+      current_user: current_resource_owner
     }
     result = SmartVillageAppMainserverSchema.execute(
       query,
@@ -28,6 +28,11 @@ class GraphqlController < ApplicationController
   end
 
   private
+
+    def current_resource_owner
+      owner_id = doorkeeper_token.try(:application).try(:owner_id) if doorkeeper_token
+      User.find(owner_id) if owner_id
+    end
 
     # Handle form data, JSON body, or a blank value
     def ensure_hash(ambiguous_param)

--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -24,11 +24,6 @@ module Mutations
     argument :location, Types::LocationInput, required: false,
                                               as: :location_attributes,
                                               prepare: ->(location, _ctx) { location.to_h }
-    argument :data_provider, Types::DataProviderInput, required: false,
-                                                       as: :data_provider_attributes,
-                                                       prepare: lambda { |data_provider, _ctx|
-                                                                  data_provider.to_h
-                                                                }
     argument :contacts, [Types::ContactInput], required: false, as: :contacts_attributes,
                                                prepare: ->(contacts, _ctx) { contacts.map(&:to_h) }
     argument :urls, [Types::WebUrlInput], required: false, as: :urls_attributes,
@@ -62,7 +57,8 @@ module Mutations
     type Types::EventRecordType
 
     def resolve(**params)
-      EventRecord.create!(params)
+      DataProviderService.new(data_provider: context[:current_user].try(:data_provider))
+        .create_resource(EventRecord, params)
     end
   end
 end

--- a/app/graphql/mutations/create_news_item.rb
+++ b/app/graphql/mutations/create_news_item.rb
@@ -16,11 +16,6 @@ module Mutations
                                             prepare: lambda { |address, _ctx|
                                                        address.to_h
                                                      }
-    argument :data_provider, Types::DataProviderInput, required: false,
-                                                       as: :data_provider_attributes,
-                                                       prepare: lambda { |data_provider, _ctx|
-                                                                  data_provider.to_h
-                                                                }
     argument :content_blocks, [Types::ContentBlockInput], required: false,
                                                           as: :content_blocks_attributes,
                                                           prepare: lambda { |content_blocks, _ctx|
@@ -32,7 +27,8 @@ module Mutations
     type Types::NewsItemType
 
     def resolve(**params)
-      NewsItem.create!(params)
+      DataProviderService.new(data_provider: context[:current_user].try(:data_provider))
+        .create_resource(NewsItem, params)
     end
   end
 end

--- a/app/graphql/mutations/create_point_of_interest.rb
+++ b/app/graphql/mutations/create_point_of_interest.rb
@@ -21,11 +21,6 @@ module Mutations
                                                         prepare: lambda { |opening_hours, _ctx|
                                                                    opening_hours.map(&:to_h)
                                                                  }
-    argument :data_provider, Types::DataProviderInput, required: false,
-                                                       as: :data_provider_attributes,
-                                                       prepare: lambda { |data_provider, _ctx|
-                                                                  data_provider.to_h
-                                                                }
     argument :operating_company, Types::OperatingCompanyInput, required: false,
                                                                as: :operating_company_attributes,
                                                                prepare:
@@ -62,7 +57,8 @@ module Mutations
     type Types::PointOfInterestType
 
     def resolve(**params)
-      PointOfInterest.create!(params)
+      DataProviderService.new(data_provider: context[:current_user].try(:data_provider))
+        .create_resource(PointOfInterest, params)
     end
   end
 end

--- a/app/graphql/mutations/create_tour.rb
+++ b/app/graphql/mutations/create_tour.rb
@@ -14,11 +14,6 @@ module Mutations
                                                 }
     argument :contact, Types::ContactInput, required: false, as: :contact_attributes,
                                             prepare: ->(contact, _ctx) { contact.to_h }
-    argument :data_provider, Types::DataProviderInput, required: false,
-                                                       as: :data_provider_attributes,
-                                                       prepare: lambda { |data_provider, _ctx|
-                                                                  data_provider.to_h
-                                                                }
     argument :operating_company, Types::OperatingCompanyInput, required: false,
                                                                as: :operating_company_attributes,
                                                                prepare:
@@ -61,7 +56,8 @@ module Mutations
     type Types::TourType
 
     def resolve(**params)
-      Tour.create!(params)
+      DataProviderService.new(data_provider: context[:current_user].try(:data_provider))
+        .create_resource(Tour, params)
     end
   end
 end

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -9,6 +9,8 @@ class Attraction < ApplicationRecord
   before_validation :find_or_create_category
 
   belongs_to :category
+  belongs_to :data_provider
+
   has_and_belongs_to_many :certificates, optional: true
   has_and_belongs_to_many :regions, optional: true
   has_many :addresses, as: :addressable
@@ -16,7 +18,6 @@ class Attraction < ApplicationRecord
   has_many :media_contents, as: :mediaable
   has_one :accessibility_information, as: :accessable
   has_one :operating_company, as: :companyable
-  has_one :data_provider, as: :provideable
   has_many :web_urls, as: :web_urlable
 
   validates_presence_of :name
@@ -49,4 +50,5 @@ end
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  type                    :string(255)      default("PointOfInterest"), not null
+#  data_provider_id        :integer
 #

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class DataProvider < ApplicationRecord
-  belongs_to :provideable, polymorphic: true
-
   has_one :address, as: :addressable
   has_one :contact, as: :contactable
   has_one :logo, as: :web_urlable, class_name: "WebUrl"
@@ -14,11 +12,9 @@ end
 #
 # Table name: data_providers
 #
-#  id               :bigint           not null, primary key
-#  name             :string(255)
-#  description      :text(65535)
-#  provideable_type :string(255)
-#  provideable_id   :bigint
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id          :bigint           not null, primary key
+#  name        :string(255)
+#  description :text(65535)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -10,8 +10,9 @@ class EventRecord < ApplicationRecord
 
   belongs_to :category, optional: true
   belongs_to :region, optional: true
+  belongs_to :data_provider
+
   has_many :urls, as: :web_urlable, class_name: "WebUrl"
-  has_one :data_provider, as: :provideable
   has_one :organizer, as: :companyable, class_name: "OperatingCompany"
   has_many :addresses, as: :addressable
   has_one :location, as: :locateable
@@ -44,13 +45,14 @@ end
 #
 # Table name: event_records
 #
-#  id          :bigint           not null, primary key
-#  parent_id   :integer
-#  region_id   :bigint
-#  description :text(65535)
-#  repeat      :boolean
-#  title       :string(255)
-#  category_id :bigint
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id               :bigint           not null, primary key
+#  parent_id        :integer
+#  region_id        :bigint
+#  description      :text(65535)
+#  repeat           :boolean
+#  title            :string(255)
+#  category_id      :bigint
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  data_provider_id :integer
 #

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -3,8 +3,9 @@
 # News Item is one of the four Main resources for the app. A news Item can be anything
 # from an old school news article to a whole story structured in chapters
 class NewsItem < ApplicationRecord
+  belongs_to :data_provider
+
   has_many :content_blocks, as: :content_blockable
-  has_one :data_provider, as: :provideable
   has_one :address, as: :addressable
   has_one :source_url, as: :web_urlable, class_name: "WebUrl"
 
@@ -25,4 +26,5 @@ end
 #  news_type              :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  data_provider_id       :integer
 #

--- a/app/models/point_of_interest.rb
+++ b/app/models/point_of_interest.rb
@@ -29,4 +29,5 @@ end
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  type                    :string(255)      default("PointOfInterest"), not null
+#  data_provider_id        :integer
 #

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -29,4 +29,5 @@ end
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  type                    :string(255)      default("PointOfInterest"), not null
+#  data_provider_id        :integer
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :trackable, :omniauthable and :rememberable
   devise :database_authenticatable, :recoverable, :validatable, :lockable, :timeoutable
-  has_one :data_provider, as: :provideable
+  belongs_to :data_provider
 
   has_many :access_grants,
            class_name: "Doorkeeper::AccessGrant",
@@ -50,4 +50,5 @@ end
 #  locked_at              :datetime
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  data_provider_id       :integer
 #

--- a/app/services/data_provider_service.rb
+++ b/app/services/data_provider_service.rb
@@ -1,0 +1,15 @@
+class DataProviderService
+  attr_accessor :data_provider
+
+  def initialize(data_provider:)
+    @data_provider = data_provider
+  end
+
+  def create_resource(resource, params)
+    item = resource.new(params)
+    item.data_provider_id = data_provider.id
+    item.save!
+
+    item
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ module SmartVillageAppMainserver
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # config.autoload_paths += Dir[Rails.root.join('app', 'models', '{**}')]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/db/migrate/20190604093234_remove_provideable_from_data_provider.rb
+++ b/db/migrate/20190604093234_remove_provideable_from_data_provider.rb
@@ -1,0 +1,6 @@
+class RemoveProvideableFromDataProvider < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :data_providers, :provideable_type, :string
+    remove_column :data_providers, :provideable_id, :string
+  end
+end

--- a/db/migrate/20190604093829_add_dataprovider_to_models.rb
+++ b/db/migrate/20190604093829_add_dataprovider_to_models.rb
@@ -1,0 +1,8 @@
+class AddDataproviderToModels < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :data_provider_id, :integer
+    add_column :news_items, :data_provider_id, :integer
+    add_column :event_records, :data_provider_id, :integer
+    add_column :attractions, :data_provider_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_28_103541) do
+ActiveRecord::Schema.define(version: 2019_06_04_093829) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "description"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type", default: "PointOfInterest", null: false
+    t.integer "data_provider_id"
     t.index ["category_id"], name: "index_attractions_on_category_id"
   end
 
@@ -108,11 +109,8 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
   create_table "data_providers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.text "description"
-    t.string "provideable_type"
-    t.bigint "provideable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["provideable_type", "provideable_id"], name: "index_data_providers_on_provideable_type_and_provideable_id"
   end
 
   create_table "event_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -124,6 +122,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
     t.bigint "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "data_provider_id"
     t.index ["category_id"], name: "index_event_records_on_category_id"
     t.index ["region_id"], name: "index_event_records_on_region_id"
   end
@@ -191,6 +190,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
     t.string "news_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "data_provider_id"
   end
 
   create_table "oauth_access_grants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
 
   create_table "prices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
-    t.float "price"
+    t.float "amount"
     t.boolean "group_price"
     t.integer "age_from"
     t.integer "age_to"
@@ -274,6 +274,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
     t.integer "min_children_count"
     t.integer "max_children_count"
     t.text "description"
+    t.string "category"
     t.string "priceable_type"
     t.bigint "priceable_id"
     t.datetime "created_at", null: false
@@ -342,6 +343,7 @@ ActiveRecord::Schema.define(version: 2019_05_28_103541) do
     t.datetime "locked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "data_provider_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/data_providers.rb
+++ b/spec/factories/data_providers.rb
@@ -10,11 +10,9 @@ end
 #
 # Table name: data_providers
 #
-#  id               :bigint           not null, primary key
-#  name             :string(255)
-#  description      :text(65535)
-#  provideable_type :string(255)
-#  provideable_id   :bigint
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id          :bigint           not null, primary key
+#  name        :string(255)
+#  description :text(65535)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #

--- a/spec/factories/event_records.rb
+++ b/spec/factories/event_records.rb
@@ -13,13 +13,14 @@ end
 #
 # Table name: event_records
 #
-#  id          :bigint           not null, primary key
-#  parent_id   :integer
-#  region_id   :bigint
-#  description :text(65535)
-#  repeat      :boolean
-#  title       :string(255)
-#  category_id :bigint
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id               :bigint           not null, primary key
+#  parent_id        :integer
+#  region_id        :bigint
+#  description      :text(65535)
+#  repeat           :boolean
+#  title            :string(255)
+#  category_id      :bigint
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  data_provider_id :integer
 #

--- a/spec/factories/news_items.rb
+++ b/spec/factories/news_items.rb
@@ -26,4 +26,5 @@ end
 #  news_type              :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  data_provider_id       :integer
 #

--- a/spec/factories/tours.rb
+++ b/spec/factories/tours.rb
@@ -21,4 +21,5 @@ end
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  type                    :string(255)      default("PointOfInterest"), not null
+#  data_provider_id        :integer
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,4 +29,5 @@ end
 #  locked_at              :datetime
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  data_provider_id       :integer
 #

--- a/spec/models/data_provider_spec.rb
+++ b/spec/models/data_provider_spec.rb
@@ -12,11 +12,9 @@ end
 #
 # Table name: data_providers
 #
-#  id               :bigint           not null, primary key
-#  name             :string(255)
-#  description      :text(65535)
-#  provideable_type :string(255)
-#  provideable_id   :bigint
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id          :bigint           not null, primary key
+#  name        :string(255)
+#  description :text(65535)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #

--- a/spec/models/event_record_spec.rb
+++ b/spec/models/event_record_spec.rb
@@ -21,13 +21,14 @@ end
 #
 # Table name: event_records
 #
-#  id          :bigint           not null, primary key
-#  parent_id   :integer
-#  region_id   :bigint
-#  description :text(65535)
-#  repeat      :boolean
-#  title       :string(255)
-#  category_id :bigint
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id               :bigint           not null, primary key
+#  parent_id        :integer
+#  region_id        :bigint
+#  description      :text(65535)
+#  repeat           :boolean
+#  title            :string(255)
+#  category_id      :bigint
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  data_provider_id :integer
 #

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -22,4 +22,5 @@ end
 #  news_type              :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  data_provider_id       :integer
 #

--- a/spec/models/point_of_interest_spec.rb
+++ b/spec/models/point_of_interest_spec.rb
@@ -31,4 +31,5 @@ end
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  type                    :string(255)      default("PointOfInterest"), not null
+#  data_provider_id        :integer
 #

--- a/spec/models/tour_spec.rb
+++ b/spec/models/tour_spec.rb
@@ -23,4 +23,5 @@ end
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  type                    :string(255)      default("PointOfInterest"), not null
+#  data_provider_id        :integer
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,4 +28,5 @@ end
 #  locked_at              :datetime
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  data_provider_id       :integer
 #


### PR DESCRIPTION
Der DataProvider wird nun nicht mehr min GraphQl übergeben sonder wird aus den Auth/Logindaten automatisch gesetzt.

Zusätzlich wird die Zuordnung zu einem DataProvider nun per "belongs_to" gesetzt, da hier keine Mehrfachzuordnungen erlaubt sind, sondern es immer genau einen DataProvider für einen Datensatz gibt.

Die polymorphische Zuordnung wurde entfernt, da sie nun überflüssig ist 