### PR TITLE
Feature/prepare resource news item for maz import

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,6 @@ require "graphql/rake_task"
 
 Rails.application.load_tasks
 
-GraphQL::RakeTask.new(schema_name: "SmartVillageAppMainserverSchema")
+GraphQL::RakeTask.new(schema_name: "SmartVillageAppMainserverSchema",
+                      idl_outfile: "public/schema.graphql",
+                      json_outfile: "public/schema.json")

--- a/app/graphql/mutations/create_news_item.rb
+++ b/app/graphql/mutations/create_news_item.rb
@@ -3,11 +3,14 @@
 module Mutations
   class CreateNewsItem < BaseMutation
     argument :author, String, required: false
+    argument :title, String, required: false
+    argument :external_id, Integer, required: false
     argument :full_version, Boolean, required: false
     argument :characters_to_be_shown, Integer, required: false
     argument :news_type, String, required: false
     argument :publication_date, String, required: false
     argument :published_at, String, required: false
+    argument :show_publish_date, Boolean, required: false
     argument :source_url, Types::WebUrlInput, required: false,
                                               as: :source_url_attributes,
                                               prepare: ->(source_url, _ctx) { source_url.to_h }

--- a/app/graphql/types/news_item_type.rb
+++ b/app/graphql/types/news_item_type.rb
@@ -3,12 +3,14 @@
 module Types
   class NewsItemType < Types::BaseObject
     field :id, ID, null: false
+    field :title, String, null: true
+    field :external_id, Integer, null: true
     field :author, String, null: true
     field :full_version, Boolean, null: true
     field :characters_to_be_shown, String, null: true
     field :publication_date, String, null: true
-    field :published_at, String, null: false
-    field :show_publish_date, Boolean, null: false
+    field :published_at, String, null: true
+    field :show_publish_date, Boolean, null: true
     field :news_type, String, null: true
     field :data_provider, DataProviderType, null: true
     field :address, AddressType, null: true

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -19,8 +19,12 @@ class ResourceService
     return external_resource.external if external_resource.present?
 
     # create resource
-    create_external_resource if resource.save
-    resource
+    if resource.save
+      create_external_resource
+      resource
+    else
+      resource.errors.messages
+    end
   end
 
   def find_external_resource
@@ -38,5 +42,6 @@ class ResourceService
       external_type: resource_class,
       unique_id: resource.unique_id
     )
+
   end
 end

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -42,6 +42,5 @@ class ResourceService
       external_type: resource_class,
       unique_id: resource.unique_id
     )
-
   end
 end

--- a/config/initializers/refresh_external_reference_unique_id.rb
+++ b/config/initializers/refresh_external_reference_unique_id.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  return unless ActiveRecord::Base.connection
 
-  if ActiveRecord::Base.connection.table_exists?("external_references")
+
+  if ActiveRecord::Base.connected? && ActiveRecord::Base.connection.table_exists?("external_references")
     ExternalReference.pluck(:external_type).uniq.each do |type|
       ExternalReference.where(external_type: type).find_each do |entry|
         refreshed_unique_id = entry.external.unique_id

--- a/db/migrate/20190619151310_add_title_and_external_id_to_news_item.rb
+++ b/db/migrate/20190619151310_add_title_and_external_id_to_news_item.rb
@@ -1,0 +1,6 @@
+class AddTitleAndExternalIdToNewsItem < ActiveRecord::Migration[5.2]
+  def change
+    add_column :news_items, :external_id, :bigint
+    add_column :news_items, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_135549) do
+ActiveRecord::Schema.define(version: 2019_06_19_151310) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "description"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2019_06_04_135549) do
   end
 
   create_table "attractions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "external_id"
     t.string "name"
     t.text "description"
     t.string "mobile_description"
@@ -199,6 +200,8 @@ ActiveRecord::Schema.define(version: 2019_06_04_135549) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "data_provider_id"
+    t.bigint "external_id"
+    t.string "title"
   end
 
   create_table "oauth_access_grants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,11 @@ doorkeeper_app = Doorkeeper::Application.new :name => 'XML-Importer', :redirect_
 doorkeeper_app.owner = user
 doorkeeper_app.save
 
+doorkeeper_app = Doorkeeper::Application.new :name => 'MAZ-Converter', :redirect_uri => 'http://localhost:5000/oauth/confirm_access'
+doorkeeper_app.owner = user
+doorkeeper_app.save
+
+
 def create_web_url
   WebUrl.create(url: Faker::Internet.url, description: Faker::Lorem.sentence)
 end

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,7 @@ npm set audit false
 rake db:migrate
 
 rake assets:precompile
+rake graphql:schema:dump
 cp -r /app/public/* /assets/
 rm -f /unicorn.pid
 


### PR DESCRIPTION
 Add title and external id to news_item

* title and external_id need to be imported for news_items to be able to perform future duplicate checks
* recreate database


Add resource errors messages to resourc service

* resoure services masks display in the graphql api of active record errors when a resource is invalid and therefore its creation fails
* this comit will fix this by returning the active record error _messages hash if a resource is not created to the graphql api instead of the invalid and unsaved  resource

Add Maz App to doorkeeper in seeds 


Remove invalid return guard clause from initializer and add check toif statement to make sure the database exists before trying to make any changes to it

