### PR TITLE
Feature/give poi openinhours the right format

### DIFF
--- a/app/graphql/types/opening_hour_type.rb
+++ b/app/graphql/types/opening_hour_type.rb
@@ -11,5 +11,45 @@ module Types
     field :sort_number, Integer, null: true
     field :open, Boolean, null: true
     field :description, String, null: true
+
+    def time_from
+      return "" if object.time_from.blank?
+
+      begin
+        object.time_from.strftime("%H:%M")
+      rescue StandardError
+        ""
+      end
+    end
+
+    def time_to
+      return "" if object.time_to.blank?
+
+      begin
+        object.time_to.strftime("%H:%M")
+      rescue StandardError
+        ""
+      end
+    end
+
+    def date_from
+      return "" if object.date_from.blank?
+
+      begin
+        object.date_from.strftime("%Y-%m-%d")
+      rescue StandardError
+        ""
+      end
+    end
+
+    def date_to
+      return "" if object.date_to.blank?
+
+      begin
+        object.date_to.strftime("%Y-%m-%d")
+      rescue StandardError
+        ""
+      end
+    end
   end
 end

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -6,7 +6,7 @@
 class Attraction < ApplicationRecord
   attr_accessor :category_name
 
-  before_validation :find_or_create_category
+  before_create :find_or_create_category
 
   belongs_to :category
   belongs_to :data_provider

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -30,7 +30,8 @@ class Attraction < ApplicationRecord
                                 :regions
 
   def find_or_create_category
-    return if self.category.present?
+    return if category.present?
+
     self.category_id = Category.where(name: category_name).first_or_create.id
   end
 end

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -6,7 +6,7 @@
 class Attraction < ApplicationRecord
   attr_accessor :category_name
 
-  before_validation :find_or_create_category
+  before_validation :set_category_id
 
   belongs_to :category
   belongs_to :data_provider
@@ -29,8 +29,18 @@ class Attraction < ApplicationRecord
                                 :data_provider, :certificates,
                                 :regions
 
+  #
+  # callback function which enables setting of category by
+  # virtual attribute category name. ATTENTION: With this callback
+  # the setting of category is only possible with category_name
+  # PointOfInterest.create(category: Category.first) doesn't work anymore.
+  #
+  def set_category_id
+    self.category_id = find_or_create_category.id
+  end
+
   def find_or_create_category
-    self.category_id = Category.where(name: category_name).first_or_create.id
+    Category.where(name: category_name).first_or_create
   end
 end
 

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -30,6 +30,7 @@ class Attraction < ApplicationRecord
                                 :regions
 
   def find_or_create_category
+    return if self.category.present?
     self.category_id = Category.where(name: category_name).first_or_create.id
   end
 end

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -6,7 +6,7 @@
 class Attraction < ApplicationRecord
   attr_accessor :category_name
 
-  before_create :find_or_create_category
+  before_validation :find_or_create_category
 
   belongs_to :category
   belongs_to :data_provider
@@ -30,8 +30,6 @@ class Attraction < ApplicationRecord
                                 :regions
 
   def find_or_create_category
-    return if category.present?
-
     self.category_id = Category.where(name: category_name).first_or_create.id
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -163,8 +163,8 @@ end
 def create_date
   FixedDate.create(
     weekday: Faker::Date.between(2000.days.ago, Date.today).strftime("%A"),
-    date_start: Faker::Date.backward.strftime("%d.%m.%y"),
-    date_end: Faker::Date.forward.strftime("%d.%m.%y"),
+    date_start: Faker::Date.backward.strftime("%d.%m.%Y"),
+    date_end: Faker::Date.forward.strftime("%d.%m.%Y"),
     time_start: Faker::Time.backward.strftime("%H:%M"),
     time_end: Faker::Time.forward.strftime("%H:%M"),
     time_description: Faker::Lorem.paragraph,
@@ -194,11 +194,11 @@ create_categories
     description: Faker::Lorem.paragraph,
     mobile_description: Faker::Lorem.paragraph,
     active: true,
-    category: Category.find(Faker::Number.within(1..3))
+    category: Category.find(Faker::Number.within(1..3)),
+    data_provider: create_data_provider
   )
   poi.addresses << create_address
   poi.contact = create_contact
-  poi.data_provider = create_data_provider
   poi.operating_company = create_operating_company
   poi.web_urls << create_web_url
   6.times do
@@ -212,6 +212,7 @@ create_categories
   poi.tag_list.add("schöne Landschaft #{n}")
   poi.save
 end
+
 10.times do |n|
   tour = Tour.create(
     external_id: Faker::Alphanumeric.alphanumeric(4),

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -194,7 +194,7 @@ create_categories
     description: Faker::Lorem.paragraph,
     mobile_description: Faker::Lorem.paragraph,
     active: true,
-    category: Category.find(Faker::Number.within(1..3)),
+    category: "Burgen und Schlösser",
     data_provider: create_data_provider
   )
   poi.addresses << create_address
@@ -220,7 +220,7 @@ end
     description: Faker::Lorem.paragraph,
     mobile_description: Faker::Lorem.paragraph,
     active: true,
-    category: Category.find(Faker::Number.within(1..3)),
+    category: "Schöne Fahrradrouten",
     length_km: Faker::Number.within(50..250),
     means_of_transportation: Faker::Number.within(0..2)
   )


### PR DESCRIPTION
Format date and time values

* time values were provided with a date
* commit will change that by using the same methods as in event records to format times and dates for openinhours values
* correct seed data to create dates with full year values (1999 instead of 99)
* correct seed data or poi with data provider because relationship between poi and data provider changed


Add guard clause to callback

* callback always overwrites category, nomatter if its is set or net
* commit will implement guard clause to check if categroy attribute is already set

#70 