### PR TITLE
Adding role to user for GraphQL

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -5,7 +5,7 @@ require "graphql/query_resolver"
 class Resolvers::EventRecordsSearch
   include SearchObject.module(:graphql)
 
-  scope { EventRecord.all }
+  scope { EventRecord.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::EventRecordType]
 

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -6,7 +6,7 @@ require "graphql/query_resolver"
 class Resolvers::NewsItemsSearch
   include SearchObject.module(:graphql)
 
-  scope { NewsItem.all }
+  scope { NewsItem.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::NewsItemType]
 

--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -6,7 +6,7 @@ require "graphql/query_resolver"
 class Resolvers::PointsOfInterestSearch
   include SearchObject.module(:graphql)
 
-  scope { PointOfInterest.all }
+  scope { PointOfInterest.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::PointOfInterestType]
 

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -6,7 +6,7 @@ require "graphql/query_resolver"
 class Resolvers::ToursSearch
   include SearchObject.module(:graphql)
 
-  scope { Tour.all }
+  scope { Tour.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::TourType]
 

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -23,6 +23,11 @@ class EventRecord < ApplicationRecord
   has_one :repeat_duration
   has_many :dates, as: :dateable, class_name: "FixedDate"
 
+  scope :filtered_for_current_user, ->(current_user) do
+    return all if current_user.admin_role?
+    where(data_provider_id: current_user.data_provider_id )
+  end
+
   accepts_nested_attributes_for :urls, reject_if: ->(attr) { attr[:url].blank? }
   accepts_nested_attributes_for :data_provider, :organizer,
                                 :addresses, :location, :contacts,

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -25,7 +25,8 @@ class EventRecord < ApplicationRecord
 
   scope :filtered_for_current_user, ->(current_user) do
     return all if current_user.admin_role?
-    where(data_provider_id: current_user.data_provider_id )
+
+    where(data_provider_id: current_user.data_provider_id)
   end
 
   accepts_nested_attributes_for :urls, reject_if: ->(attr) { attr[:url].blank? }

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -9,6 +9,11 @@ class NewsItem < ApplicationRecord
   has_one :address, as: :addressable
   has_one :source_url, as: :web_urlable, class_name: "WebUrl"
 
+  scope :filtered_for_current_user, ->(current_user) do
+    return all if current_user.admin_role?
+    where(data_provider_id: current_user.data_provider_id )
+  end
+
   accepts_nested_attributes_for :content_blocks, :data_provider, :address, :source_url
 
   def unique_id

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -11,7 +11,8 @@ class NewsItem < ApplicationRecord
 
   scope :filtered_for_current_user, ->(current_user) do
     return all if current_user.admin_role?
-    where(data_provider_id: current_user.data_provider_id )
+
+    where(data_provider_id: current_user.data_provider_id)
   end
 
   accepts_nested_attributes_for :content_blocks, :data_provider, :address, :source_url

--- a/app/models/point_of_interest.rb
+++ b/app/models/point_of_interest.rb
@@ -10,6 +10,11 @@ class PointOfInterest < Attraction
 
   has_one :location, as: :locateable
 
+  scope :filtered_for_current_user, ->(current_user) do
+    return all if current_user.admin_role?
+    where(data_provider_id: current_user.data_provider_id )
+  end
+
   accepts_nested_attributes_for :prices, :opening_hours, :location
 
   def unique_id

--- a/app/models/point_of_interest.rb
+++ b/app/models/point_of_interest.rb
@@ -12,7 +12,8 @@ class PointOfInterest < Attraction
 
   scope :filtered_for_current_user, ->(current_user) do
     return all if current_user.admin_role?
-    where(data_provider_id: current_user.data_provider_id )
+
+    where(data_provider_id: current_user.data_provider_id)
   end
 
   accepts_nested_attributes_for :prices, :opening_hours, :location

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -12,7 +12,8 @@ class Tour < Attraction
 
   scope :filtered_for_current_user, ->(current_user) do
     return all if current_user.admin_role?
-    where(data_provider_id: current_user.data_provider_id )
+
+    where(data_provider_id: current_user.data_provider_id)
   end
 
   accepts_nested_attributes_for :geometry_tour_data, :location

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -10,6 +10,11 @@ class Tour < Attraction
 
   has_one :location, as: :locateable
 
+  scope :filtered_for_current_user, ->(current_user) do
+    return all if current_user.admin_role?
+    where(data_provider_id: current_user.data_provider_id )
+  end
+
   accepts_nested_attributes_for :geometry_tour_data, :location
 
   def unique_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   # :confirmable, :trackable, :omniauthable and :rememberable
   devise :database_authenticatable, :recoverable, :validatable, :lockable, :timeoutable
 
+  enum role: { user: 0, admin: 1 }, _suffix: :role
+
   belongs_to :data_provider, optional: true
 
   has_many :access_grants,
@@ -20,11 +22,6 @@ class User < ApplicationRecord
   has_many :oauth_applications,
            class_name: "Doorkeeper::Application",
            as: :owner
-
-  def admin?
-    # TODO: Dies muss eine Rechte- und Rollenverwaltung übernehmen
-    true
-  end
 end
 
 # == Schema Information

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -22,7 +22,7 @@ Doorkeeper.configure do
     # Example implementation:
 
     if current_user
-      head :forbidden unless current_user.admin?
+      head :forbidden unless current_user.admin_role?
     else
       redirect_to new_user_session_path
     end

--- a/db/migrate/20190621153829_add_role_to_users.rb
+++ b/db/migrate/20190621153829_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_151310) do
+ActiveRecord::Schema.define(version: 2019_06_21_153829) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "description"
@@ -355,6 +355,7 @@ ActiveRecord::Schema.define(version: 2019_06_19_151310) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "data_provider_id"
+    t.integer "role", default: 0
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
The goal is for the mobile app to continue reading all data as before, but the individual importer accounts will only be able to read/retrieve their own data.

- adding enum :role in model user. Default is :user
  This generates method like „user_role?“ and „admin_role?“
- removes temp method admin?
- replaces new role_method in doorkeeper initializer
- adding a scope : filtered_for_current_user to every queryModel (:tour, :event, :poi, :news_item)
- extending the scopes in graphql queries to use the new model scopes

**!!! As soon as this feature is online, the account for the mobile app has to be adapted online and the role has to be changed to admin (role: 1). Otherwise no data will be visible in the app !!!**