### PR TITLE
Fix bug in graphql contact type

### DIFF
--- a/app/graphql/types/contact_type.rb
+++ b/app/graphql/types/contact_type.rb
@@ -6,7 +6,7 @@ module Types
     field :first_name, String, null: true
     field :last_name, String, null: true
     field :phone, String, null: true
-    field :fax, Boolean, null: true
+    field :fax, String, null: true
     field :web_urls, [WebUrlType], null: true
     field :email, String, null: true
   end


### PR DESCRIPTION
* graphql type contact had field fax which was Boolean but should have been String
* this lead to fax always return true instead of a fax number
* change fax to type String to fix bug

#97