### PR TITLE
Feature/sort events with event date

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -79,8 +79,6 @@ class Resolvers::EventRecordsSearch
     scope.sort_by(&:list_date).reverse
   end
 
-
-
   # https://github.com/nettofarah/graphql-query-resolver
 
   def fetch_results

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -72,11 +72,11 @@ class Resolvers::EventRecordsSearch
   end
 
   def apply_order_with_list_date_desc(scope)
-    scope.sort_by(&:list_date)
+    scope.sort_by(&:list_date).reverse
   end
 
   def apply_order_with_list_date_asc(scope)
-    scope.sort_by(&:list_date).reverse
+    scope.sort_by(&:list_date)
   end
 
   # https://github.com/nettofarah/graphql-query-resolver

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -18,9 +18,12 @@ class Resolvers::EventRecordsSearch
     value "title_DESC"
     value "id_ASC"
     value "id_DESC"
+    value "listDate_DESC"
+    value "listDate_ASC"
   end
 
   option :limit, type: types.Int, with: :apply_limit
+  option :take, type: types.Int, with: :apply_take
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
 
@@ -30,6 +33,10 @@ class Resolvers::EventRecordsSearch
 
   def apply_skip(scope, value)
     scope.offset(value)
+  end
+
+  def apply_take(scope, value)
+    scope.take(value)
   end
 
   def apply_order_with_created_at_desc(scope)
@@ -63,6 +70,16 @@ class Resolvers::EventRecordsSearch
   def apply_order_with_id_asc(scope)
     scope.order("id ASC")
   end
+
+  def apply_order_with_list_date_desc(scope)
+    scope.sort_by(&:list_date)
+  end
+
+  def apply_order_with_list_date_asc(scope)
+    scope.sort_by(&:list_date).reverse
+  end
+
+
 
   # https://github.com/nettofarah/graphql-query-resolver
 

--- a/app/graphql/types/event_record_type.rb
+++ b/app/graphql/types/event_record_type.rb
@@ -7,6 +7,7 @@ module Types
     field :description, String, null: true
     field :title, String, null: true
     field :dates, [DateType], null: true
+    field :list_date, String, null: true
     field :repeat, Boolean, null: true
     field :repeat_duration, RepeatDurationType, null: true
     field :category, CategoryType, null: true

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -5,6 +5,7 @@ class EventRecord < ApplicationRecord
   attr_accessor :category_name
   attr_accessor :region_name
   attr_accessor :force_create
+  attr_accessor :list_date
 
   before_validation :find_or_create_category
   before_validation :find_or_create_region
@@ -59,6 +60,10 @@ class EventRecord < ApplicationRecord
     date_fields = date_keys.map { |d| date.try(:send, d) }
 
     generate_checksum(fields + address_fields + date_fields)
+  end
+
+  def list_date
+    dates.order(date_start: :asc).first
   end
 end
 

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -63,11 +63,11 @@ class EventRecord < ApplicationRecord
 
   def list_date
     event_dates = dates.order(date_start: :asc)
-    future_date = event_dates.select { |date| date.date_start > Time.zone.now }.first
+    future_date = event_dates.select { |date| date.date_start > Time.zone.now }.first.try(:date_start)
 
     return future_date if future_date.present?
 
-    event_dates.last
+    event_dates.last.try(:date_start)
   end
 end
 

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -5,7 +5,6 @@ class EventRecord < ApplicationRecord
   attr_accessor :category_name
   attr_accessor :region_name
   attr_accessor :force_create
-  attr_accessor :list_date
 
   before_validation :find_or_create_category
   before_validation :find_or_create_region
@@ -25,11 +24,11 @@ class EventRecord < ApplicationRecord
   has_one :repeat_duration, dependent: :destroy
   has_many :dates, as: :dateable, class_name: "FixedDate", dependent: :destroy
 
-  scope :filtered_for_current_user, ->(current_user) do
+  scope :filtered_for_current_user, lambda { |current_user|
     return all if current_user.admin_role?
 
     where(data_provider_id: current_user.data_provider_id)
-  end
+  }
 
   accepts_nested_attributes_for :urls, reject_if: ->(attr) { attr[:url].blank? }
   accepts_nested_attributes_for :data_provider, :organizer,

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -62,7 +62,12 @@ class EventRecord < ApplicationRecord
   end
 
   def list_date
-    dates.order(date_start: :asc).first
+    event_dates = dates.order(date_start: :asc)
+    future_date = event_dates.select { |date| date.date_start > Time.zone.now }.first
+
+    return future_date if future_date.present?
+
+    event_dates.last
   end
 end
 

--- a/spec/factories/data_providers.rb
+++ b/spec/factories/data_providers.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :data_provider do
     name { "MyString" }
-    logo { "MyString" }
     description { "MyString" }
   end
 end

--- a/spec/factories/event_records.rb
+++ b/spec/factories/event_records.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     description { "A Reading with an Author" }
     repeat { false }
     title { "MyString" }
-    data_provider { create(:data_provider)}
+    data_provider { create(:data_provider) }
 
     factory :event_record_with_dates do
       transient do

--- a/spec/factories/event_records.rb
+++ b/spec/factories/event_records.rb
@@ -2,10 +2,20 @@
 
 FactoryBot.define do
   factory :event_record do
-    region { "MyString" }
-    description { "MyString" }
+    description { "A Reading with an Author" }
     repeat { false }
     title { "MyString" }
+    data_provider { create(:data_provider)}
+
+    factory :event_record_with_dates do
+      transient do
+        dates_count { 5 }
+      end
+
+      after(:create) do |event_record, evaluator|
+        create_list(:event_record, evaluator.dates_count, event_record: event_record)
+      end
+    end
   end
 end
 

--- a/spec/factories/fixed_dates.rb
+++ b/spec/factories/fixed_dates.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     time_end { "2019-05-06 12:17:44" }
     time_Description { "MyString" }
     use_only_time_description { false }
-    dateable { nil }
   end
 end
 

--- a/spec/factories/web_urls.rb
+++ b/spec/factories/web_urls.rb
@@ -1,7 +1,11 @@
 FactoryBot.define do
   factory :web_url do
-    url { "MyString" }
+    for_data_provider
+    url { "http://www.test.de" }
     description { "MyString" }
+    trait :for_data_provider do
+      association(:web_urlable, factory: :data_provider)
+    end
   end
 end
 

--- a/spec/models/event_record_spec.rb
+++ b/spec/models/event_record_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe EventRecord, type: :model do
         future_date_2 = "21.12.2101"
         add_date_to(er_1, future_date_1)
         add_date_to(er_1, future_date_2)
-        result = er_1.list_date.date_start.strftime("%d.%m.%Y")
+        result = er_1.list_date.strftime("%d.%m.%Y")
         expect(result).to eq(future_date_1)
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe EventRecord, type: :model do
         past_date_2 = "21.05.2019"
         add_date_to(er_1, past_date_1)
         add_date_to(er_1, past_date_2)
-        result = er_1.list_date.date_start.strftime("%d.%m.%Y")
+        result = er_1.list_date.strftime("%d.%m.%Y")
         expect(result).to eq(past_date_2)
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe EventRecord, type: :model do
         add_date_to(er_1, future_date_1)
         add_date_to(er_1, future_date_2)
         add_date_to(er_1, past_date)
-        result = er_1.list_date.date_start.strftime("%d.%m.%Y")
+        result = er_1.list_date.strftime("%d.%m.%Y")
         expect(result).to eq(future_date_1)
       end
     end

--- a/spec/models/event_record_spec.rb
+++ b/spec/models/event_record_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe EventRecord, type: :model do
         expect(result).to eq(future_date_1)
       end
     end
+
     context "with an event who has two past dates" do
       it "returns the date closest to now" do
         er_1 = event_record_1
@@ -60,6 +61,7 @@ RSpec.describe EventRecord, type: :model do
         expect(result).to eq(past_date_2)
       end
     end
+
     context "with an event who has a past and two future date" do
       it "returns the future date which is closest to now" do
         er_1 = event_record_1

--- a/spec/models/event_record_spec.rb
+++ b/spec/models/event_record_spec.rb
@@ -3,10 +3,13 @@
 require "rails_helper"
 
 RSpec.describe EventRecord, type: :model do
+  let(:event_record_2) { create(:event_record) }
+  let(:event_record_1) { create(:event_record) }
+
   it { is_expected.to have_many(:addresses) }
   it { is_expected.to have_many(:contacts) }
   it { is_expected.to have_one(:organizer) }
-  it { is_expected.to have_one(:data_provider) }
+  it { is_expected.to belong_to(:data_provider) }
   it { is_expected.to have_many(:price_informations) }
   it { is_expected.to have_many(:media_contents) }
   it { is_expected.to have_one(:location) }
@@ -15,6 +18,62 @@ RSpec.describe EventRecord, type: :model do
   it { is_expected.to have_many(:urls) }
   it { is_expected.to have_many(:dates) }
   it { is_expected.to validate_presence_of(:title) }
+
+  def create_date(date_start)
+    FixedDate.create(
+      weekday: Faker::Date.between(2000.days.ago, Date.today).strftime("%A"),
+      date_start: date_start,
+      date_end: date_start,
+      time_start: Faker::Time.backward.strftime("%H:%M"),
+      time_end: Faker::Time.forward.strftime("%H:%M"),
+      time_description: Faker::Lorem.paragraph,
+      use_only_time_description: Faker::Boolean.boolean(0.8)
+    )
+  end
+
+  def add_date_to(event_record, date_start = Time.zone.now)
+    event_record.dates << create_date(date_start)
+
+    event_record.save
+  end
+
+  describe "#list_date" do
+    context "with an event who has two future dates" do
+      it "returns the date closest to now" do
+        er_1 = event_record_1
+        future_date_1 = "21.12.2100"
+        future_date_2 = "21.12.2101"
+        add_date_to(er_1, future_date_1)
+        add_date_to(er_1, future_date_2)
+        result = er_1.list_date.date_start.strftime("%d.%m.%Y")
+        expect(result).to eq(future_date_1)
+      end
+    end
+    context "with an event who has two past dates" do
+      it "returns the date closest to now" do
+        er_1 = event_record_1
+        past_date_1 = "20.12.2018"
+        past_date_2 = "21.05.2019"
+        add_date_to(er_1, past_date_1)
+        add_date_to(er_1, past_date_2)
+        result = er_1.list_date.date_start.strftime("%d.%m.%Y")
+        expect(result).to eq(past_date_2)
+      end
+    end
+    context "with an event who has a past and two future date" do
+      it "returns the future date which is closest to now" do
+        er_1 = event_record_1
+        future_date_1 = "21.12.2100"
+        future_date_2 = "21.12.2101"
+        past_date = "21.05.2019"
+        add_date_to(er_1, future_date_1)
+        add_date_to(er_1, future_date_2)
+        add_date_to(er_1, past_date)
+        result = er_1.list_date.date_start.strftime("%d.%m.%Y")
+        expect(result).to eq(future_date_1)
+      end
+    end
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
Add virtual attribute list_date to return latest date for an event

* one event can  have many dates :list_date will return the  date which lies furthest in the future


Add list date to Event Records Search as an option to sort an order Events

*  add list_date to EventRecordOrder ENUM
* Add methods which resolve new enums
* new methods use sort_by instead of order because list_date is a virtual_attribute is not queried directly in the database
* add aplpy_take method because virtual_attribute return Array of Event Records and is not a direct ActiveRecord query where limit can be applied

graphql queries which return event records ordered by list_date look like this:

<img width="1209" alt="grafik" src="https://user-images.githubusercontent.com/31201899/60187657-382e8080-982e-11e9-91f6-79984f1f1940.png">

<img width="1215" alt="grafik" src="https://user-images.githubusercontent.com/31201899/60187734-5e542080-982e-11e9-819c-b855b9c48e6a.png">

#86 