### PR TITLE
Rename prices to price_informations where necessary

### DIFF
--- a/app/graphql/mutations/create_point_of_interest.rb
+++ b/app/graphql/mutations/create_point_of_interest.rb
@@ -13,10 +13,12 @@ module Mutations
                                                 prepare: lambda { |addresses, _ctx|
                                                   addresses.map(&:to_h)
                                                 }
-    argument :contact, Types::ContactInput, required: false, as: :contact_attributes,
-                                            prepare: ->(contact, _ctx) { contact.to_h }
-    argument :price_informations, [Types::PriceInput], required: false, as: :price_informations_attributes,
-                                           prepare: ->(price_informations, _ctx) { price_informations.map(&:to_h) }
+    argument :contact, Types::ContactInput,
+             required: false, as: :contact_attributes,
+             prepare: ->(contact, _ctx) { contact.to_h }
+    argument :price_informations, [Types::PriceInput],
+             required: false, as: :price_informations_attributes,
+             prepare: ->(price_informations, _ctx) { price_informations.map(&:to_h) }
     argument :opening_hours, [Types::OpeningHourInput], required: false,
                                                         as: :opening_hours_attributes,
                                                         prepare: lambda { |opening_hours, _ctx|

--- a/app/graphql/mutations/create_point_of_interest.rb
+++ b/app/graphql/mutations/create_point_of_interest.rb
@@ -15,8 +15,8 @@ module Mutations
                                                 }
     argument :contact, Types::ContactInput, required: false, as: :contact_attributes,
                                             prepare: ->(contact, _ctx) { contact.to_h }
-    argument :prices, [Types::PriceInput], required: false, as: :prices_attributes,
-                                           prepare: ->(prices, _ctx) { prices.map(&:to_h) }
+    argument :price_informations, [Types::PriceInput], required: false, as: :price_informations_attributes,
+                                           prepare: ->(price_informations, _ctx) { price_informations.map(&:to_h) }
     argument :opening_hours, [Types::OpeningHourInput], required: false,
                                                         as: :opening_hours_attributes,
                                                         prepare: lambda { |opening_hours, _ctx|

--- a/app/graphql/types/point_of_interest_type.rb
+++ b/app/graphql/types/point_of_interest_type.rb
@@ -16,7 +16,7 @@ module Types
     field :media_contents, [MediaContentType], null: true
     field :operating_company, OperatingCompanyType, null: true
     field :opening_hours, [OpeningHourType], null: true
-    field :prices, [PriceType], null: true
+    field :price_informations, [PriceType], null: true
     field :certificates, [CertificateType], null: true
     field :accessibility_information, AccessibilityInformationType, null: true
     field :tag_list, [String], null: true

--- a/app/models/point_of_interest.rb
+++ b/app/models/point_of_interest.rb
@@ -18,7 +18,7 @@ class PointOfInterest < Attraction
     where(data_provider_id: current_user.data_provider_id)
   end
 
-  accepts_nested_attributes_for :prices, :opening_hours, :location
+  accepts_nested_attributes_for :price_informations, :opening_hours, :location
 
   def unique_id
     fields = [name, type]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -202,7 +202,7 @@ create_categories
   poi.operating_company = create_operating_company
   poi.web_urls << create_web_url
   6.times do
-    poi.prices << create_price
+    poi.price_informations << create_price
     poi.opening_hours << create_opening_hour
     poi.media_contents << create_media_content
   end

--- a/doc/poi_mutation_example.graphql
+++ b/doc/poi_mutation_example.graphql
@@ -58,7 +58,7 @@ mutation {
 				{ url: "http://www.test2.de", description: "url 2" }
 			]
 		}
-		prices: [
+		price_informations: [
 			{ name: "Standardkarte", amount: 5.89, groupPrice: false, description: "Tarif gilt nicht in den Ferien" }
 			{
 				name: "Familienkarte"
@@ -187,7 +187,7 @@ mutation {
 			regionId
 			state
 		}
-		prices {
+		price_informations {
 			name
 			amount
 			description

--- a/spec/models/point_of_interest_spec.rb
+++ b/spec/models/point_of_interest_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe PointOfInterest, type: :model do
   it { is_expected.to have_many(:addresses) }
   it { is_expected.to have_one(:contact) }
   it { is_expected.to have_one(:operating_company) }
-  it { is_expected.to have_one(:data_provider) }
+  it { is_expected.to belong_to(:data_provider) }
   it { is_expected.to have_many(:media_contents) }
   it { is_expected.to have_many(:web_urls) }
   it { is_expected.to have_many(:opening_hours) }
-  it { is_expected.to have_many(:prices) }
+  it { is_expected.to have_many(:price_informations) }
   it { is_expected.to have_one(:accessibility_information) }
   it { is_expected.to validate_presence_of(:name) }
 end


### PR DESCRIPTION
Im vorherigen PR in dem prices eigentlich umbenannt worden ist, haben noch einige Stellen gefhlt  wo auch noch prices steht. Diese stellen sind nach merge dieses Pr auch in price_informations geändert