### PR TITLE
Feature/add update function to news item

### DIFF
--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -19,7 +19,7 @@ class Attraction < ApplicationRecord
   has_one :accessibility_information, as: :accessable, dependent: :destroy
   has_one :operating_company, as: :companyable, dependent: :destroy
   has_many :web_urls, as: :web_urlable, dependent: :destroy
-
+  has_one :external_reference, as: :external, dependent: :destroy
   validates_presence_of :name
   acts_as_taggable
 

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DataProvider < ApplicationRecord
+  store :always_recreate, accessors: %i[point_of_interest tour news_item event_record], coder: JSON
+
   has_one :address, as: :addressable
   has_one :contact, as: :contactable
   has_one :logo, as: :web_urlable, class_name: "WebUrl"

--- a/app/models/event_record.rb
+++ b/app/models/event_record.rb
@@ -23,6 +23,8 @@ class EventRecord < ApplicationRecord
   has_many :media_contents, as: :mediaable, dependent: :destroy
   has_one :repeat_duration, dependent: :destroy
   has_many :dates, as: :dateable, class_name: "FixedDate", dependent: :destroy
+  has_one :external_reference, as: :external, dependent: :destroy
+
 
   scope :filtered_for_current_user, lambda { |current_user|
     return all if current_user.admin_role?

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -30,7 +30,7 @@ class NewsItem < ApplicationRecord
   end
 
   def data_provider_maz?
-    return true if data_provider == "MAZ - Märkische Allgemeine"
+    return true if data_provider.always_recreate == true
   end
 end
 

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -8,6 +8,7 @@ class NewsItem < ApplicationRecord
   belongs_to :data_provider
 
   has_many :content_blocks, as: :content_blockable, dependent: :destroy
+  has_one :external_reference, as: :external, dependent: :destroy
   has_one :address, as: :addressable, dependent: :destroy
   has_one :source_url, as: :web_urlable, class_name: "WebUrl", dependent: :destroy
 
@@ -20,10 +21,15 @@ class NewsItem < ApplicationRecord
   accepts_nested_attributes_for :content_blocks, :data_provider, :address, :source_url
 
   def unique_id
+    return external_id if data_provider_maz? && external_id.present?
     title = content_blocks.first.try(:title)
     fields = [title, published_at]
 
     generate_checksum(fields)
+  end
+
+  def data_provider_maz?
+    return true if data_provider == "MAZ - Märkische Allgemeine"
   end
 end
 

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -21,16 +21,12 @@ class NewsItem < ApplicationRecord
   accepts_nested_attributes_for :content_blocks, :data_provider, :address, :source_url
 
   def unique_id
-    return external_id if data_provider_maz? && external_id.present?
+    return external_id if external_id.present?
 
     title = content_blocks.first.try(:title)
     fields = [title, published_at]
 
     generate_checksum(fields)
-  end
-
-  def data_provider_maz?
-    return true if data_provider.always_recreate == true
   end
 end
 

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -22,6 +22,7 @@ class NewsItem < ApplicationRecord
 
   def unique_id
     return external_id if data_provider_maz? && external_id.present?
+
     title = content_blocks.first.try(:title)
     fields = [title, published_at]
 

--- a/app/models/point_of_interest.rb
+++ b/app/models/point_of_interest.rb
@@ -9,9 +9,7 @@ class PointOfInterest < Attraction
 
   has_many :opening_hours, as: :openingable, dependent: :destroy
   has_many :price_informations, as: :priceable, class_name: "Price", dependent: :destroy
-
   has_one :location, as: :locateable, dependent: :destroy
-
   scope :filtered_for_current_user, ->(current_user) do
     return all if current_user.admin_role?
 

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -9,7 +9,6 @@ class Tour < Attraction
 
   has_many :geometry_tour_data, as: :geo_locateable, class_name: "GeoLocation", dependent: :destroy
   has_one :location, as: :locateable, dependent: :destroy
-
   enum means_of_transportation: { bike: 0, canoe: 1, foot: 2 }
 
   scope :filtered_for_current_user, ->(current_user) do

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -40,11 +40,8 @@ class ResourceService
   def unchanged_attributes?(record)
     return false if record.blank?
 
-    resource_attributes = @resource.attributes.except("id", "created_at", "updated_at", "tag_list",
-                                                      "category_id", "region_id")
-    record_attributes = record.attributes.except("id", "created_at", "updated_at", "tag_list",
-                                                 "category_id", "region_id")
-    resource_attributes == record_attributes
+    except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id"]
+    @resource.attributes.except(*except_attributes) == old_record.attributes.except(*except_attributes)
   end
 
   def not_maz?(data_provider)

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -20,7 +20,7 @@ class ResourceService
     old_record = external_resource.try(:external)
     return old_record if external_resource.present? &&
                          unchanged_attributes?(old_record) &&
-                         not_maz?(data_provider)
+                         not_always_recreate?(data_provider, resource_class)
 
     create_or_recreate(old_record, external_resource)
     resource_or_error_message(resource)
@@ -41,13 +41,14 @@ class ResourceService
     return false if record.blank?
 
     except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id"]
-    @resource.attributes.except(*except_attributes) == old_record.attributes.except(*except_attributes)
+    @resource.attributes.except(*except_attributes) == record.attributes.except(*except_attributes)
   end
 
-  def not_maz?(data_provider)
+  def not_always_recreate?(data_provider, resource_class)
     return false if data_provider.blank?
 
-    data_provider.always_recreate != true
+    class_name = resource_class.name.underscore
+    data_provider.always_recreate[class_name] != true
   end
 
   def find_external_resource

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -11,7 +11,6 @@ class ResourceService
 
   def create(resource_class, params)
     @params = params
-    p params
     @resource_class = resource_class
     @resource = resource_class.new(params)
     @resource.data_provider = data_provider

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -11,17 +11,34 @@ class ResourceService
 
   def create(resource_class, params)
     @params = params
+    p params
     @resource_class = resource_class
     @resource = resource_class.new(params)
     @resource.data_provider = data_provider
-
-    # skip create if already exists
+    # skip create if record already exists and new record has the same attribute values as the new record and the record was not provided by maz
     external_resource = find_external_resource
-    return external_resource.external if external_resource.present?
+    old_record = external_resource.try(:external)
+    return old_record if external_resource.present? && unchanged_attributes?(old_record) && not_maz?(data_provider)
 
-    # create resource
-    create_external_resource if resource.save
+    # destroy the old record and its external_reference if its attributes changed or if the data_provider is MAZ
+    old_record.destroy if old_record.present?
+    # necessary because dependant: :destroy sometimes works for external resource and sometimes doesn't
+    # TODO: Remove line and make dependant: :destroy work
+    external_resource.destroy if external_resource.present?
+    create_external_resource if @resource.save
     resource_or_error_message(resource)
+  end
+
+  def unchanged_attributes?(record)
+    return false if record.blank?
+
+    @resource.attributes.except("id", "created_at", "updated_at", "tag_list", "category_id", "region_id") == record.attributes.except("id", "created_at", "updated_at", "tag_list", "category_id", "region_id")
+  end
+
+  def not_maz?(data_provider)
+    return false if data_provider.blank?
+
+    data_provider.name != "MAZ - Märkische Allgemeine"
   end
 
   def find_external_resource

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -20,7 +20,7 @@ class ResourceService
     old_record = external_resource.try(:external)
     return old_record if external_resource.present? &&
                          unchanged_attributes?(old_record) &&
-                         not_always_recreate?(data_provider, resource_class)
+                         !always_recreate?(data_provider, resource_class)
 
     create_or_recreate(old_record, external_resource)
     resource_or_error_message(resource)
@@ -44,11 +44,11 @@ class ResourceService
     @resource.attributes.except(*except_attributes) == record.attributes.except(*except_attributes)
   end
 
-  def not_always_recreate?(data_provider, resource_class)
+  def always_recreate?(data_provider, resource_class)
     return false if data_provider.blank?
 
     class_name = resource_class.name.underscore
-    data_provider.always_recreate[class_name] != true
+    data_provider.always_recreate[class_name] == true
   end
 
   def find_external_resource

--- a/db/migrate/20190710092939_add_always_recreate_to_data_provider.rb
+++ b/db/migrate/20190710092939_add_always_recreate_to_data_provider.rb
@@ -1,0 +1,5 @@
+class AddAlwaysRecreateToDataProvider < ActiveRecord::Migration[5.2]
+  def change
+    add_column :data_providers, :always_recreate, :boolean, default: false
+  end
+end

--- a/db/migrate/20190710092939_add_always_recreate_to_data_provider.rb
+++ b/db/migrate/20190710092939_add_always_recreate_to_data_provider.rb
@@ -1,5 +1,5 @@
 class AddAlwaysRecreateToDataProvider < ActiveRecord::Migration[5.2]
   def change
-    add_column :data_providers, :always_recreate, :boolean, default: false
+    add_column :data_providers, :always_recreate, :text
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_125951) do
+ActiveRecord::Schema.define(version: 2019_07_10_092939) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "description"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_125951) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "always_recreate", default: false
   end
 
   create_table "event_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2019_07_10_092939) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "always_recreate", default: false
+    t.text "always_recreate"
   end
 
   create_table "event_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -189,12 +189,11 @@ create_categories
 
 10.times do |n|
   poi = PointOfInterest.create(
-    external_id: Faker::Alphanumeric.alphanumeric(4),
     name: "Burg #{n}",
     description: Faker::Lorem.paragraph,
     mobile_description: Faker::Lorem.paragraph,
     active: true,
-    category: "Burgen und Schlösser",
+    category_name: "Burgen und Schlösser",
     data_provider: create_data_provider
   )
   poi.addresses << create_address
@@ -215,12 +214,11 @@ end
 
 10.times do |n|
   tour = Tour.create(
-    external_id: Faker::Alphanumeric.alphanumeric(4),
     name: "Tour #{n}",
     description: Faker::Lorem.paragraph,
     mobile_description: Faker::Lorem.paragraph,
     active: true,
-    category: "Schöne Fahrradrouten",
+    category_name: "Schöne Fahrradrouten",
     length_km: Faker::Number.within(50..250),
     means_of_transportation: Faker::Number.within(0..2)
   )
@@ -249,7 +247,7 @@ end
       end_date: Faker::Date.forward.strftime("%d.%m.%y"),
       every_year: Faker::Boolean.boolean(0.3)
     ),
-    category: Category.find(Faker::Number.within(1..3)),
+    category_name: "Konzerte",
     region: create_region
   )
   event.addresses << create_address

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,14 +13,13 @@ user = User.create(
   password: "kBzWAvNCWqn2rJxG",
   password_confirmation: "kBzWAvNCWqn2rJxG"
 )
-doorkeeper_app = Doorkeeper::Application.new :name => 'XML-Importer', :redirect_uri => 'http://localhost:3000/oauth/confirm_access'
+doorkeeper_app = Doorkeeper::Application.new name: "XML-Importer", redirect_uri: "http://localhost:3000/oauth/confirm_access"
 doorkeeper_app.owner = user
 doorkeeper_app.save
 
-doorkeeper_app = Doorkeeper::Application.new :name => 'MAZ-Converter', :redirect_uri => 'http://localhost:5000/oauth/confirm_access'
+doorkeeper_app = Doorkeeper::Application.new name: "MAZ-Converter", redirect_uri: "http://localhost:5000/oauth/confirm_access"
 doorkeeper_app.owner = user
 doorkeeper_app.save
-
 
 def create_web_url
   WebUrl.create(url: Faker::Internet.url, description: Faker::Lorem.sentence)

--- a/spec/models/data_provider_spec.rb
+++ b/spec/models/data_provider_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DataProvider, type: :model do
   it { is_expected.to have_one(:address) }
   it { is_expected.to have_one(:contact) }
-  it { is_expected.to belong_to(:provideable) }
+  it { is_expected.to have_one(:logo) }
 end
 
 # == Schema Information

--- a/spec/services/resource_service_spec.rb
+++ b/spec/services/resource_service_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ResourceService, type: :service do
+  let(:maz) { create(:data_provider, name: "MAZ - Märkische Allgemeine") }
+  let(:tmb) { create(:data_provider, name: "TMB") }
+  let(:news_item_1) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
+  let(:news_item_2) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
+  let(:poi_1) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }
+  let(:poi_1_changed) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi_changed) }
+  let(:poi_2) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }
+  let(:tour_1){ ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
+  let(:tour_1_changed){ ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour_changed) }
+  let(:tour_2){ ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
+  let(:event_1){ ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
+  let(:event_1_changed){ ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event_changed) }
+  let(:event_2){ ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
+
+  def params_maz
+    { author: "Robert sdf",
+      external_id: 76_594,
+      full_version: true,
+      characters_to_be_shown: 10_000,
+      news_type: "story",
+      publication_date: "057",
+      published_at: "07.07.2",
+      source_url_attributes: { url: "http://www.ews.de", description: "source url of original article" },
+      address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default",
+                            geo_location_attributes: { latitude: 7.45018, longitude: 102.279 } },
+      content_blocks_attributes: [{
+        title: "Lorem sit amet consectetur adipiscing",
+        intro: "Lorem ante ultriceatm torquent sit volutpat. Eros malesuada pretium sociosqu magnis mauris parturennaeos suspendisse tincidunt conu.",
+        body: "Lorem ipsum dolor sit amet consectetaiicn,lttnciunt iaculis praesent ut. Nunc  hendrerit turpis himenaeos vestibulum sapien ae nostra erat lacus duis phasellus habitant, facilisis pretium iaculis commodo vivamus platea et eleifend tempor convallis tristique, lobortis cursus dapibus sem aenean mauris ac sagittis laoreet parturient senectus. Tortor eros curabitur congue ipsum vulputate dapibus montes tristique, accumsan hendrerit placerat praesent imperdiet laoreet mauris, luctus et turpis lacinia metus torquent lobortis.Interdum diam viverra libero hendrerit mauris adipiscing in odio faucibus, curae massa fusce nisi sed id tempor pulvinar, sit ante metus habitasse molestie fames nascetur rhoncus. Cum erat torquent tristique quis volutpat vulputate dui euismod sit integer, tincidunt iaculis non laoreet amet elementum nullam nascetur phasellus, potenti lacinia ultrices mauris vel habitant hac ligula feugiat pharetra, cras aptent leo lectus massa turpis tortor risus. Bt magnis sollicitudin. Conubia faucibus est nec felis ornare inceptos purus, integer proin dis at tempor class porta commodo, donec auctor ad mollis bibendum curae. Consequat bibendum turpis sem duis accumsan pharetra, tristique potenti pretium integer nec, lacus placerat quam sodales sit. Rhoncus cras mus penatibus sed lacinia eget consectetur fusce class tincidunt, condimentum iaculis eu fames hendrerit metus feugiat vehicula per, elementum bibendum nam pretium vitae pulvinar ridiculus a lacus.",
+        media_contents_attributes: [
+          { caption_text: "Lorem ipsum dolor sit amet consectetur adipiscing",
+            copyright: "Lorem Merol",
+            height: 7865,
+            width: 346,
+            content_type: "image" }
+        ]
+      }] }
+  end
+
+  def params_tmb_poi
+    { name: "test", description: "Lorem ipsum dolor sit amet consectetur adipiscing", active: true, category_name: "Burgen", addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", geo_location_attributes: { latitude: 832_764.37264, longitude: 8_723_647.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2" }], contact_attributes: { first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }, price_informations_attributes: [{ name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" }, { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }], opening_hours_attributes: [{ weekday: "Friday", date_from: "19-08-18", date_to: "25-03-20", time_from: "08:44:00 UTC", time_to: "00:02:00 UTC", sort_number: 1, open: true, description: "Ut id veritatis nihil." }], operating_company_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: -7.45018, longitude: -102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, web_urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], location_attributes: { name: "Raben", department: "Niemegk", district: "Potsdam-Mittelmark", region_name: "Flaeming", state: "Brandenburg", geo_location_attributes: { latitude: 52.042051020544, longitude: 12.577602953518 } }, certificates_attributes: [{ name: "Qualitätssiegel Premium Schwimmbäder" }, { name: "Qualitätssiegel besondere Burg" }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["[swim, swam, swum]"] }
+  end
+
+  def params_tmb_poi_changed
+    { name: "test", description: "r sit amet consectetur adipiscing", active: true, category_name: "Burgen", addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", geo_location_attributes: { latitude: 832_764.37264, longitude: 8_723_647.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2" }], contact_attributes: { first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }, price_informations_attributes: [{ name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" }, { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }], opening_hours_attributes: [{ weekday: "Friday", date_from: "19-08-18", date_to: "25-03-20", time_from: "08:44:00 UTC", time_to: "00:02:00 UTC", sort_number: 1, open: true, description: "Ut id veritatis nihil." }], operating_company_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: -7.45018, longitude: -102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, web_urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], location_attributes: { name: "Raben", department: "Niemegk", district: "Potsdam-Mittelmark", region_name: "Flaeming", state: "Brandenburg", geo_location_attributes: { latitude: 52.042051020544, longitude: 12.577602953518 } }, certificates_attributes: [{ name: "Qualitätssiegel Premium Schwimmbäder" }, { name: "Qualitätssiegel besondere Burg" }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["[swim, swam, swum]"] }
+  end
+
+  def params_tmb_tour
+    {:name=>"Wandern durch Berlin", :description=>"description", :active=>true, :category_name=>"Wandertour", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contact_attributes=>{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}, :operating_company_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>-7.45018, :longitude=>-102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :web_urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Natuacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :length_km=>500, :means_of_transportation=>"bike", :geometry_tour_data_attributes=>[{:latitude=>64.37264, :longitude=>45.431234}, {:latitude=>32.37264, :longitude=>40.431234}, {:latitude=>36.37264, :longitude=>49.431234}, {:latitude=>39.37264, :longitude=>41.431234}, {:latitude=>41.37264, :longitude=>43.431234}], :tag_list=>["[swim, swam, swum]"]}
+  end
+
+  def params_tmb_tour_changed
+    {:name=>"Wandern durch Berlin", :description=>"description changed", :active=>true, :category_name=>"Wandertour", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contact_attributes=>{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}, :operating_company_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>-7.45018, :longitude=>-102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :web_urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Natuacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :length_km=>500, :means_of_transportation=>"bike", :geometry_tour_data_attributes=>[{:latitude=>64.37264, :longitude=>45.431234}, {:latitude=>32.37264, :longitude=>40.431234}, {:latitude=>36.37264, :longitude=>49.431234}, {:latitude=>39.37264, :longitude=>41.431234}, {:latitude=>41.37264, :longitude=>43.431234}], :tag_list=>["[swim, swam, swum]"]}
+  end
+
+  def params_tmb_event
+    {:parent_id=>1, :description=>"Lorem ipsum dolor sit  consectetur adipiscing", :title=>"Test", :dates_attributes=>[{:weekday=>"Monday", :time_start=>"16:00", :time_end=>"18:00", :time_description=>"das Training findet jeden zweiten Montag im Monat statt", :use_only_time_description=>false}], :repeat=>true, :repeat_duration_attributes=>{:start_date=>"0001-12-18", :end_date=>"0021-07-19", :every_year=>true}, :category_name=>"category name", :region_name=>"Flaeming", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contacts_attributes=>[{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}], :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Naturwacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :organizer_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>7.45018, :longitude=>102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :price_informations_attributes=>[{:name=>"Standardkarte", :amount=>5.89, :group_price=>false, :description=>"Tarif gilt nicht in den Ferien"}, {:name=>"Familienkarte", :amount=>18.0, :group_price=>true, :age_from=>2, :age_to=>17, :min_adult_count=>10, :max_adult_count=>17, :min_children_count=>3, :max_children_count=>9, :description=>"Tarif gilt nur in den Ferien."}], :accessibility_information_attributes=>{:description=>"bla", :types=>"Tops", :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"eewrgr"}]}, :tag_list=>["megaparty", "technoclassix", "underground"]}
+  end
+
+  def params_tmb_event_changed
+    {:parent_id=>1, :description=>"Changed Lorem ipsum dolor sit  consectetur adipiscing", :title=>"Test", :dates_attributes=>[{:weekday=>"Monday", :time_start=>"16:00", :time_end=>"18:00", :time_description=>"das Training findet jeden zweiten Montag im Monat statt", :use_only_time_description=>false}], :repeat=>true, :repeat_duration_attributes=>{:start_date=>"0001-12-18", :end_date=>"0021-07-19", :every_year=>true}, :category_name=>"category name", :region_name=>"Flaeming", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contacts_attributes=>[{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}], :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Naturwacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :organizer_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>7.45018, :longitude=>102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :price_informations_attributes=>[{:name=>"Standardkarte", :amount=>5.89, :group_price=>false, :description=>"Tarif gilt nicht in den Ferien"}, {:name=>"Familienkarte", :amount=>18.0, :group_price=>true, :age_from=>2, :age_to=>17, :min_adult_count=>10, :max_adult_count=>17, :min_children_count=>3, :max_children_count=>9, :description=>"Tarif gilt nur in den Ferien."}], :accessibility_information_attributes=>{:description=>"bla", :types=>"Tops", :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"eewrgr"}]}, :tag_list=>["megaparty", "technoclassix", "underground"]}
+  end
+
+  describe "#create" do
+    context "when creating a 'maz-NewsItem'" do
+      context "with an external_id" do
+        context "which already exists in the database" do
+          before do
+            news_item_1
+            news_item_2
+          end
+
+          it "deletes the old record" do
+            expect(NewsItem.exists?(news_item_1.id)).to eq(false)
+          end
+          it "creates a new record" do
+            expect(NewsItem.exists?(news_item_2.id)).to eq(true)
+          end
+          it "the new record has the same external_id as the old one" do
+            expect(news_item_1.external_id).to eq(news_item_2.external_id)
+          end
+        end
+      end
+    end
+
+    context "when creating any other resource" do
+      context "which is exactly matching an exiting one" do
+        before do
+          poi_1
+          tour_1
+          event_1
+        end
+        it "doesn't create a new record" do
+          poi_2
+          tour_2
+          event_2
+          expect(poi_2.id).to eq(poi_1.id)
+          expect(tour_2.id).to eq(tour_1.id)
+          expect(event_2.id).to eq(event_1.id)
+        end
+        it "returns the existing record" do
+          poi_2
+          tour_2
+          event_2
+          expect(poi_2).to eq(poi_1)
+          expect(tour_2).to eq(tour_1)
+          expect(event_2).to eq(event_1)
+        end
+      end
+      context "which is changing an exiting one" do
+        before do
+          poi_1
+          tour_1
+          event_1
+        end
+        it "creates a new record" do
+          poi_1_changed
+          tour_1_changed
+          event_1_changed
+          expect(poi_1_changed.id).not_to eq(poi_1.id)
+          expect(tour_1_changed.id).not_to eq(tour_1.id)
+          expect(event_1_changed.id).not_to eq(event_1.id)
+          expect(PointOfInterest.exists?(poi_1_changed.id)).to eq(true)
+          expect(Tour.exists?(tour_1_changed.id)).to eq(true)
+          expect(EventRecord.exists?(event_1_changed.id)).to eq(true)
+        end
+        it "destroys the old record" do
+          poi_1_changed
+          tour_1_changed
+          event_1_changed
+          expect(PointOfInterest.exists?(poi_1.id)).to eq(false)
+          expect(Tour.exists?(tour_1.id)).to eq(false)
+          expect(EventRecord.exists?(event_1.id)).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/resource_service_spec.rb
+++ b/spec/services/resource_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ResourceService, type: :service do
-  let(:maz) { create(:data_provider, name: "MAZ - Märkische Allgemeine", always_recreate: true) }
-  let(:tmb) { create(:data_provider, name: "TMB", always_recreate: false) }
+  let(:maz) { create(:data_provider, name: "MAZ", news_item: true) }
+  let(:tmb) { create(:data_provider, name: "TMB") }
   let(:news_item_1) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
   let(:news_item_2) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
   let(:poi_1) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }

--- a/spec/services/resource_service_spec.rb
+++ b/spec/services/resource_service_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ResourceService, type: :service do
-  let(:maz) { create(:data_provider, name: "MAZ - Märkische Allgemeine") }
-  let(:tmb) { create(:data_provider, name: "TMB") }
+  let(:maz) { create(:data_provider, name: "MAZ - Märkische Allgemeine", always_recreate: true) }
+  let(:tmb) { create(:data_provider, name: "TMB", always_recreate: false) }
   let(:news_item_1) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
   let(:news_item_2) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
   let(:poi_1) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }

--- a/spec/services/resource_service_spec.rb
+++ b/spec/services/resource_service_spec.rb
@@ -152,22 +152,20 @@ RSpec.describe ResourceService, type: :service do
 
   describe "#create" do
     context "when creating a 'maz-NewsItem'" do
-      context "with an external_id" do
-        context "which already exists in the database" do
-          before do
-            news_item_1
-            news_item_2
-          end
+      context "with an external_id which already exists in the database" do
+        before do
+          news_item_1
+          news_item_2
+        end
 
-          it "deletes the old record" do
-            expect(NewsItem.exists?(news_item_1.id)).to eq(false)
-          end
-          it "creates a new record" do
-            expect(NewsItem.exists?(news_item_2.id)).to eq(true)
-          end
-          it "the new record has the same external_id as the old one" do
-            expect(news_item_1.external_id).to eq(news_item_2.external_id)
-          end
+        it "deletes the old record" do
+          expect(NewsItem.exists?(news_item_1.id)).to eq(false)
+        end
+        it "creates a new record" do
+          expect(NewsItem.exists?(news_item_2.id)).to eq(true)
+        end
+        it "the new record has the same external_id as the old one" do
+          expect(news_item_1.external_id).to eq(news_item_2.external_id)
         end
       end
     end

--- a/spec/services/resource_service_spec.rb
+++ b/spec/services/resource_service_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe ResourceService, type: :service do
   let(:poi_1) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }
   let(:poi_1_changed) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi_changed) }
   let(:poi_2) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }
-  let(:tour_1){ ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
-  let(:tour_1_changed){ ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour_changed) }
-  let(:tour_2){ ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
-  let(:event_1){ ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
-  let(:event_1_changed){ ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event_changed) }
-  let(:event_2){ ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
+  let(:tour_1) { ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
+  let(:tour_1_changed) { ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour_changed) }
+  let(:tour_2) { ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
+  let(:event_1) { ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
+  let(:event_1_changed) { ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event_changed) }
+  let(:event_2) { ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
 
   def params_maz
     { author: "Robert sdf",
@@ -43,7 +43,91 @@ RSpec.describe ResourceService, type: :service do
   end
 
   def params_tmb_poi
-    { name: "test", description: "Lorem ipsum dolor sit amet consectetur adipiscing", active: true, category_name: "Burgen", addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", geo_location_attributes: { latitude: 832_764.37264, longitude: 8_723_647.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2" }], contact_attributes: { first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }, price_informations_attributes: [{ name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" }, { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }], opening_hours_attributes: [{ weekday: "Friday", date_from: "19-08-18", date_to: "25-03-20", time_from: "08:44:00 UTC", time_to: "00:02:00 UTC", sort_number: 1, open: true, description: "Ut id veritatis nihil." }], operating_company_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: -7.45018, longitude: -102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, web_urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], location_attributes: { name: "Raben", department: "Niemegk", district: "Potsdam-Mittelmark", region_name: "Flaeming", state: "Brandenburg", geo_location_attributes: { latitude: 52.042051020544, longitude: 12.577602953518 } }, certificates_attributes: [{ name: "Qualitätssiegel Premium Schwimmbäder" }, { name: "Qualitätssiegel besondere Burg" }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["[swim, swam, swum]"] }
+    { name: "test",
+      description: "Lorem ipsum dolor sit amet consectetur adipiscing",
+      active: true,
+      category_name: "Burgen",
+      addresses_attributes: [
+        { addition: "Bahnhof",
+          street: "Musterstraße",
+          zip: "10100",
+          city: "Berlin",
+          geo_location_attributes: {
+            latitude: 832_764.37264, longitude: 8_723_647.9347
+          } },
+        { addition: "Bahnhof 2",
+          street: "Musterstraße2",
+          zip: "10100",
+          city: "Berlin2" }
+      ],
+      contact_attributes: {
+        first_name: "Tim",
+        last_name: "Test",
+        phone: "012345678",
+        fax: "09843729047",
+        web_urls_attributes: [
+          { url: "http://www.test1.de", description: "url 1" },
+          { url: "http://www.test2.de", description: "url 2" }
+        ],
+        email: "test@test.de"
+      },
+      price_informations_attributes: [
+        { name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" },
+        { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }
+      ],
+      opening_hours_attributes: [
+        {
+          weekday: "Friday",
+          date_from: "19-08-18",
+          date_to: "25-03-20",
+          time_from: "08:44:00 UTC",
+          time_to: "00:02:00 UTC",
+          sort_number: 1,
+          open: true,
+          description: "Ut id veritatis nihil."
+        }
+      ],
+      operating_company_attributes: {
+        name: "McClure, Kemmer and Brown",
+        address_attributes: {
+          street: "Abbie Manors",
+          zip: "25083",
+          city: "Mialand",
+          kind: "default",
+          geo_location_attributes: { latitude: -7.45018, longitude: -102.279 }
+        },
+        contact_attributes: {
+          first_name: "Alonzo",
+          last_name: "Von",
+          phone: "+235 782-754-0007 x80976",
+          web_urls_attributes: [
+            {
+              url: "http://ebert.biz/teri.beahan",
+              description: "Temporibus autem qui at."
+            }
+          ]
+        }
+      },
+      web_urls_attributes: [
+        { url: "http://www.hoher-flaeming-naturpark.de",
+          description: "Naturpark Hoher Fläming" },
+        { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }
+      ],
+      media_contents_attributes: [
+        {
+          caption_text: "Qui dolore fugit rem.",
+          copyright: "Zane Marquardt",
+          height: 342,
+          width: 215,
+          content_type: "image",
+          source_url_attributes: {
+            url: "https://www.image.file",
+            description: "main image"
+          }
+        }, {
+          caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video"
+        }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }
+      ], location_attributes: { name: "Raben", department: "Niemegk", district: "Potsdam-Mittelmark", region_name: "Flaeming", state: "Brandenburg", geo_location_attributes: { latitude: 52.042051020544, longitude: 12.577602953518 } }, certificates_attributes: [{ name: "Qualitätssiegel Premium Schwimmbäder" }, { name: "Qualitätssiegel besondere Burg" }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["[swim, swam, swum]"] }
   end
 
   def params_tmb_poi_changed
@@ -51,19 +135,19 @@ RSpec.describe ResourceService, type: :service do
   end
 
   def params_tmb_tour
-    {:name=>"Wandern durch Berlin", :description=>"description", :active=>true, :category_name=>"Wandertour", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contact_attributes=>{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}, :operating_company_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>-7.45018, :longitude=>-102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :web_urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Natuacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :length_km=>500, :means_of_transportation=>"bike", :geometry_tour_data_attributes=>[{:latitude=>64.37264, :longitude=>45.431234}, {:latitude=>32.37264, :longitude=>40.431234}, {:latitude=>36.37264, :longitude=>49.431234}, {:latitude=>39.37264, :longitude=>41.431234}, {:latitude=>41.37264, :longitude=>43.431234}], :tag_list=>["[swim, swam, swum]"]}
+    { name: "Wandern durch Berlin", description: "description", active: true, category_name: "Wandertour", addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", kind: "start", geo_location_attributes: { latitude: 64.37264, longitude: 47.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2", kind: "end" }], contact_attributes: { first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }, operating_company_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: -7.45018, longitude: -102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, web_urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Natuacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], length_km: 500, means_of_transportation: "bike", geometry_tour_data_attributes: [{ latitude: 64.37264, longitude: 45.431234 }, { latitude: 32.37264, longitude: 40.431234 }, { latitude: 36.37264, longitude: 49.431234 }, { latitude: 39.37264, longitude: 41.431234 }, { latitude: 41.37264, longitude: 43.431234 }], tag_list: ["[swim, swam, swum]"] }
   end
 
   def params_tmb_tour_changed
-    {:name=>"Wandern durch Berlin", :description=>"description changed", :active=>true, :category_name=>"Wandertour", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contact_attributes=>{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}, :operating_company_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>-7.45018, :longitude=>-102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :web_urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Natuacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :length_km=>500, :means_of_transportation=>"bike", :geometry_tour_data_attributes=>[{:latitude=>64.37264, :longitude=>45.431234}, {:latitude=>32.37264, :longitude=>40.431234}, {:latitude=>36.37264, :longitude=>49.431234}, {:latitude=>39.37264, :longitude=>41.431234}, {:latitude=>41.37264, :longitude=>43.431234}], :tag_list=>["[swim, swam, swum]"]}
+    { name: "Wandern durch Berlin", description: "description changed", active: true, category_name: "Wandertour", addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", kind: "start", geo_location_attributes: { latitude: 64.37264, longitude: 47.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2", kind: "end" }], contact_attributes: { first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }, operating_company_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: -7.45018, longitude: -102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, web_urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Natuacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], length_km: 500, means_of_transportation: "bike", geometry_tour_data_attributes: [{ latitude: 64.37264, longitude: 45.431234 }, { latitude: 32.37264, longitude: 40.431234 }, { latitude: 36.37264, longitude: 49.431234 }, { latitude: 39.37264, longitude: 41.431234 }, { latitude: 41.37264, longitude: 43.431234 }], tag_list: ["[swim, swam, swum]"] }
   end
 
   def params_tmb_event
-    {:parent_id=>1, :description=>"Lorem ipsum dolor sit  consectetur adipiscing", :title=>"Test", :dates_attributes=>[{:weekday=>"Monday", :time_start=>"16:00", :time_end=>"18:00", :time_description=>"das Training findet jeden zweiten Montag im Monat statt", :use_only_time_description=>false}], :repeat=>true, :repeat_duration_attributes=>{:start_date=>"0001-12-18", :end_date=>"0021-07-19", :every_year=>true}, :category_name=>"category name", :region_name=>"Flaeming", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contacts_attributes=>[{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}], :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Naturwacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :organizer_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>7.45018, :longitude=>102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :price_informations_attributes=>[{:name=>"Standardkarte", :amount=>5.89, :group_price=>false, :description=>"Tarif gilt nicht in den Ferien"}, {:name=>"Familienkarte", :amount=>18.0, :group_price=>true, :age_from=>2, :age_to=>17, :min_adult_count=>10, :max_adult_count=>17, :min_children_count=>3, :max_children_count=>9, :description=>"Tarif gilt nur in den Ferien."}], :accessibility_information_attributes=>{:description=>"bla", :types=>"Tops", :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"eewrgr"}]}, :tag_list=>["megaparty", "technoclassix", "underground"]}
+    { parent_id: 1, description: "Lorem ipsum dolor sit  consectetur adipiscing", title: "Test", dates_attributes: [{ weekday: "Monday", time_start: "16:00", time_end: "18:00", time_description: "das Training findet jeden zweiten Montag im Monat statt", use_only_time_description: false }], repeat: true, repeat_duration_attributes: { start_date: "0001-12-18", end_date: "0021-07-19", every_year: true }, category_name: "category name", region_name: "Flaeming", addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", kind: "start", geo_location_attributes: { latitude: 64.37264, longitude: 47.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2", kind: "end" }], contacts_attributes: [{ first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }], urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], organizer_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: 7.45018, longitude: 102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, price_informations_attributes: [{ name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" }, { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["megaparty", "technoclassix", "underground"] }
   end
 
   def params_tmb_event_changed
-    {:parent_id=>1, :description=>"Changed Lorem ipsum dolor sit  consectetur adipiscing", :title=>"Test", :dates_attributes=>[{:weekday=>"Monday", :time_start=>"16:00", :time_end=>"18:00", :time_description=>"das Training findet jeden zweiten Montag im Monat statt", :use_only_time_description=>false}], :repeat=>true, :repeat_duration_attributes=>{:start_date=>"0001-12-18", :end_date=>"0021-07-19", :every_year=>true}, :category_name=>"category name", :region_name=>"Flaeming", :addresses_attributes=>[{:addition=>"Bahnhof", :street=>"Musterstraße", :zip=>"10100", :city=>"Berlin", :kind=>"start", :geo_location_attributes=>{:latitude=>64.37264, :longitude=>47.9347}}, {:addition=>"Bahnhof 2", :street=>"Musterstraße2", :zip=>"10100", :city=>"Berlin2", :kind=>"end"}], :contacts_attributes=>[{:first_name=>"Tim", :last_name=>"Test", :phone=>"012345678", :fax=>"09843729047", :web_urls_attributes=>[{:url=>"http://www.test1.de", :description=>"url 1"}, {:url=>"http://www.test2.de", :description=>"url 2"}], :email=>"test@test.de"}], :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"Naturpark Hoher Fläming"}, {:url=>"http://www.naturwacht.de", :description=>"Naturwacht Brandenburg"}], :media_contents_attributes=>[{:caption_text=>"Qui dolore fugit rem.", :copyright=>"Zane Marquardt", :height=>342, :width=>215, :content_type=>"image", :source_url_attributes=>{:url=>"https://www.image.file", :description=>"main image"}}, {:caption_text=>"Id molestias omnis repellat.", :copyright=>"Dr. Willard Klocko", :height=>315, :width=>607, :content_type=>"video"}, {:caption_text=>"Provident quidem sed velit.", :copyright=>"Verona Lowe", :height=>348, :width=>766, :content_type=>"soundcloud-audio"}], :organizer_attributes=>{:name=>"McClure, Kemmer and Brown", :address_attributes=>{:street=>"Abbie Manors", :zip=>"25083", :city=>"Mialand", :kind=>"default", :geo_location_attributes=>{:latitude=>7.45018, :longitude=>102.279}}, :contact_attributes=>{:first_name=>"Alonzo", :last_name=>"Von", :phone=>"+235 782-754-0007 x80976", :web_urls_attributes=>[{:url=>"http://ebert.biz/teri.beahan", :description=>"Temporibus autem qui at."}]}}, :price_informations_attributes=>[{:name=>"Standardkarte", :amount=>5.89, :group_price=>false, :description=>"Tarif gilt nicht in den Ferien"}, {:name=>"Familienkarte", :amount=>18.0, :group_price=>true, :age_from=>2, :age_to=>17, :min_adult_count=>10, :max_adult_count=>17, :min_children_count=>3, :max_children_count=>9, :description=>"Tarif gilt nur in den Ferien."}], :accessibility_information_attributes=>{:description=>"bla", :types=>"Tops", :urls_attributes=>[{:url=>"http://www.hoher-flaeming-naturpark.de", :description=>"eewrgr"}]}, :tag_list=>["megaparty", "technoclassix", "underground"]}
+    { parent_id: 1, description: "Changed Lorem ipsum dolor sit  consectetur adipiscing", title: "Test", dates_attributes: [{ weekday: "Monday", time_start: "16:00", time_end: "18:00", time_description: "das Training findet jeden zweiten Montag im Monat statt", use_only_time_description: false }], repeat: true, repeat_duration_attributes: { start_date: "0001-12-18", end_date: "0021-07-19", every_year: true }, category_name: "category name", region_name: "Flaeming", addresses_attributes: [{ addition: "Bahnhof", street: "Musterstraße", zip: "10100", city: "Berlin", kind: "start", geo_location_attributes: { latitude: 64.37264, longitude: 47.9347 } }, { addition: "Bahnhof 2", street: "Musterstraße2", zip: "10100", city: "Berlin2", kind: "end" }], contacts_attributes: [{ first_name: "Tim", last_name: "Test", phone: "012345678", fax: "09843729047", web_urls_attributes: [{ url: "http://www.test1.de", description: "url 1" }, { url: "http://www.test2.de", description: "url 2" }], email: "test@test.de" }], urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "Naturpark Hoher Fläming" }, { url: "http://www.naturwacht.de", description: "Naturwacht Brandenburg" }], media_contents_attributes: [{ caption_text: "Qui dolore fugit rem.", copyright: "Zane Marquardt", height: 342, width: 215, content_type: "image", source_url_attributes: { url: "https://www.image.file", description: "main image" } }, { caption_text: "Id molestias omnis repellat.", copyright: "Dr. Willard Klocko", height: 315, width: 607, content_type: "video" }, { caption_text: "Provident quidem sed velit.", copyright: "Verona Lowe", height: 348, width: 766, content_type: "soundcloud-audio" }], organizer_attributes: { name: "McClure, Kemmer and Brown", address_attributes: { street: "Abbie Manors", zip: "25083", city: "Mialand", kind: "default", geo_location_attributes: { latitude: 7.45018, longitude: 102.279 } }, contact_attributes: { first_name: "Alonzo", last_name: "Von", phone: "+235 782-754-0007 x80976", web_urls_attributes: [{ url: "http://ebert.biz/teri.beahan", description: "Temporibus autem qui at." }] } }, price_informations_attributes: [{ name: "Standardkarte", amount: 5.89, group_price: false, description: "Tarif gilt nicht in den Ferien" }, { name: "Familienkarte", amount: 18.0, group_price: true, age_from: 2, age_to: 17, min_adult_count: 10, max_adult_count: 17, min_children_count: 3, max_children_count: 9, description: "Tarif gilt nur in den Ferien." }], accessibility_information_attributes: { description: "bla", types: "Tops", urls_attributes: [{ url: "http://www.hoher-flaeming-naturpark.de", description: "eewrgr" }] }, tag_list: ["megaparty", "technoclassix", "underground"] }
   end
 
   describe "#create" do
@@ -95,6 +179,7 @@ RSpec.describe ResourceService, type: :service do
           tour_1
           event_1
         end
+
         it "doesn't create a new record" do
           poi_2
           tour_2
@@ -112,12 +197,14 @@ RSpec.describe ResourceService, type: :service do
           expect(event_2).to eq(event_1)
         end
       end
+
       context "which is changing an exiting one" do
         before do
           poi_1
           tour_1
           event_1
         end
+
         it "creates a new record" do
           poi_1_changed
           tour_1_changed


### PR DESCRIPTION
Add necessary features to news item

* for news items from maz unique_id will be external_id to find and update extising news_items from maz
*  add dependant: :destroy if a news item is destroyed its external reference should be destroyed as well

Add dependant: :destroy to main resources

* if a record is destroyed its external_refernce should be destroyed as well. Otherwise the same record cannot be created again because of check in resource service

Change resource_service#create to update record possible

*  add logic if a new resource equals an existing resource
* if it differs, the old resource and its external reference will be destroyed and the new resource will be saved otherwise the old resource will be returned
*  exception for data_provider MAZ: a new maz resource which has the same external_id as an existing resource will always be created and the old one will always be destroyed
* add spec to test and describe new logic

Remove debug logging 

Change attributes in seeds to make them work 

#58