### PR TITLE
Add feature to destroy_record mutation

### DIFF
--- a/app/graphql/mutations/destroy_record.rb
+++ b/app/graphql/mutations/destroy_record.rb
@@ -24,24 +24,26 @@ module Mutations
       OpenStruct.new(id: id, status: result[:status], status_code: result[:status_code])
     end
 
-    def error_status
-      OpenStruct.new(id: nil, status: "Access not permitted", status_code: 403)
-    end
+    private
 
-    def find_record(record_type, search_hash)
-      record_type.constantize
-        .filtered_for_current_user(context[:current_user])
-        .where(search_hash)
-        .first
-    end
-
-    def destroy_record(record)
-      if record.present?
-        record.destroy
-        { status: "Record destroyed", status_code: 200 }
-      else
-        { status: "Record not found", status_code: 404 }
+      def error_status
+        OpenStruct.new(id: nil, status: "Access not permitted", status_code: 403)
       end
-    end
+
+      def find_record(record_type, search_hash)
+        record_type.constantize
+          .filtered_for_current_user(context[:current_user])
+          .where(search_hash)
+          .first
+      end
+
+      def destroy_record(record)
+        if record.present?
+          record.destroy
+          { status: "Record destroyed", status_code: 200 }
+        else
+          { status: "Record not found", status_code: 404 }
+        end
+      end
   end
 end

--- a/app/graphql/mutations/destroy_record.rb
+++ b/app/graphql/mutations/destroy_record.rb
@@ -18,10 +18,10 @@ module Mutations
                else
                  find_record(record_type, id: id)
                end
-      destroy_record(record)
+      result = destroy_record(record)
       id ||= record.try(:id)
 
-      OpenStruct.new(id: id, status: status, status_code: status_code)
+      OpenStruct.new(id: id, status: result[:status], status_code: result[:status_code])
     end
 
     def error_status
@@ -38,11 +38,9 @@ module Mutations
     def destroy_record(record)
       if record.present?
         record.destroy
-        status = "Record destroyed"
-        status_code = 200
+        { status: "Record destroyed", status_code: 200 }
       else
-        status = "Record not found"
-        status_code = 404
+        { status: "Record not found", status_code: 404 }
       end
     end
   end

--- a/app/graphql/mutations/destroy_record.rb
+++ b/app/graphql/mutations/destroy_record.rb
@@ -18,15 +18,7 @@ module Mutations
                else
                  find_record(record_type, id: id)
                end
-      if record.present?
-        record.destroy
-        status = "Record destroyed"
-        status_code = 200
-      else
-        status = "Record not found"
-        status_code = 404
-      end
-
+      destroy_record(record)
       id ||= record.try(:id)
 
       OpenStruct.new(id: id, status: status, status_code: status_code)
@@ -41,6 +33,17 @@ module Mutations
         .filtered_for_current_user(context[:current_user])
         .where(search_hash)
         .first
+    end
+
+    def destroy_record(record)
+      if record.present?
+        record.destroy
+        status = "Record destroyed"
+        status_code = 200
+      else
+        status = "Record not found"
+        status_code = 404
+      end
     end
   end
 end


### PR DESCRIPTION
* add argument external_id to make deletion of a record by external_id possible
* this way maz can send a delete request to maz converter with an external_id and destroy_record mutation can find a record to be destroyed by external_id


PR connected to the following other PRs:
https://github.com/ikuseiGmbH/smart-village-app-converter-json2graphql/pull/3
https://github.com/ikuseiGmbH/smart-village-app-maz-converter/pull/2

It needs to be reviewed together with them.