### PR TITLE
Add category filter to tour and point of interest

### DIFF
--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -25,6 +25,7 @@ class Resolvers::PointsOfInterestSearch
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: PointsOfInterestOrder, default: "createdAt_DESC"
+  option :category, type: types.String, with: :apply_category
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -36,6 +37,10 @@ class Resolvers::PointsOfInterestSearch
 
   def apply_order(scope, value)
     scope.order(value)
+  end
+
+  def apply_category(scope, value)
+    scope.joins(:category).where(categories: { name: value })
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -25,6 +25,7 @@ class Resolvers::ToursSearch
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: ToursOrder, default: "createdAt_DESC"
+  option :category, type: types.String, with: :apply_category
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -36,6 +37,10 @@ class Resolvers::ToursSearch
 
   def apply_order(scope, value)
     scope.order(value)
+  end
+
+  def apply_category(scope, value)
+    scope.joins(:category).where(categories: { name: value })
   end
 
   def apply_order_with_created_at_desc(scope)


### PR DESCRIPTION
* add category option  and method to search resolver objects to be able to query for pois or tours which belong to a certain category

<img width="1193" alt="grafik" src="https://user-images.githubusercontent.com/31201899/62314371-20809280-b493-11e9-87d7-a27f9339d1da.png">

<img width="1176" alt="grafik" src="https://user-images.githubusercontent.com/31201899/62314385-25454680-b493-11e9-9de6-05b3bbc2d5f4.png">

closes #113 