### PR TITLE
Change time_Description to time_description

### DIFF
--- a/app/graphql/types/date_input.rb
+++ b/app/graphql/types/date_input.rb
@@ -7,7 +7,7 @@ module Types
     argument :date_end, String, required: false
     argument :time_start, String, required: false
     argument :time_end, String, required: false
-    argument :time_Description, String, required: false
+    argument :time_description, String, required: false
     argument :use_only_time_description, Boolean, required: false
   end
 end

--- a/spec/factories/fixed_dates.rb
+++ b/spec/factories/fixed_dates.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     weekday { "MyString" }
     time_start { "2019-05-06 12:17:44" }
     time_end { "2019-05-06 12:17:44" }
-    time_Description { "MyString" }
+    time_description { "MyString" }
     use_only_time_description { false }
   end
 end


### PR DESCRIPTION
Is it necessary to write a capital D in `time_Description`?
If not, we can merge this PR for an all lowercase argument `time_description`.