### PR TITLE
Add fields for model counts to CategoryType

### DIFF
--- a/app/graphql/types/category_type.rb
+++ b/app/graphql/types/category_type.rb
@@ -4,5 +4,7 @@ module Types
   class CategoryType < Types::BaseObject
     field :id, ID, null: true
     field :name, String, null: true
+    field :points_of_interest_count, Integer, null: true
+    field :tours_count, Integer, null: true
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,6 +6,24 @@ class Category < ApplicationRecord
   has_ancestry
   validates_presence_of :name
   has_one :event_record
+  has_many :points_of_interest,
+           -> { where(attractions: { type: "PointOfInterest" }) },
+           class_name: "Attraction"
+  has_many :tours,
+           -> { where(attractions: { type: "Tour" }) },
+           class_name: "Attraction"
+
+  def points_of_interest_count
+    return 0 if points_of_interest.blank?
+
+    points_of_interest.count
+  end
+
+  def tours_count
+    return 0 if tours.blank?
+
+    tours.count
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
- we need to group by categories for points of interest or tours in the mobile app
- we do not want to render empty categories (without any counts)
- added count fields for both to graphql CategoryType
- added methods for that fields to model Category

<img width="1077" alt="Bildschirmfoto 2019-08-02 um 13 44 14" src="https://user-images.githubusercontent.com/1942953/62368404-caf8c400-b52c-11e9-84fe-56f129f23f79.png">

updates #116 