### PR TITLE
Feature/add error logging for graphql execution errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem "graphql-query-resolver"
 gem "search_object"
 gem "search_object_graphql"
 gem "unicorn"
+gem "gelf"
+gem "lograge"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       railties (>= 4.2.0)
     ffi (1.11.1)
     formatador (0.2.5)
+    gelf (3.1.0)
+      json
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.7.0)
@@ -145,6 +147,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -217,6 +224,8 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rb-readline (0.5.5)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
@@ -343,6 +352,7 @@ DEPENDENCIES
   factory_bot
   factory_bot_rails
   faker!
+  gelf
   graphiql-rails
   graphql
   graphql-query-resolver
@@ -352,6 +362,7 @@ DEPENDENCIES
   jquery-rails
   linter!
   listen (>= 3.0.5, < 3.2)
+  lograge
   mysql2 (>= 0.4.4, < 0.6.0)
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,11 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  config.log_level = :debug
+
+  config.logger = GELF::Logger.new("localhost", 12219, "WAN", { :facility => "Main App Server" })
+
+
   # Show full error reports.
   config.consider_all_requests_local = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+  config.logger = GELF::Logger.new("localhost", 12219, "WAN", { :facility => "YOUR_APP_NAME" })
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)

--- a/config/lograge.rb
+++ b/config/lograge.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::Graylog2.new
+end


### PR DESCRIPTION
Vorschlag zur Lösung von #67 
Add GELF with Lograge as new standard logging method in production and development

* In production we are using graylog so the rails logs should be formatted  as  gelf messages


Add Message to the Error Log if the GraphQL Server throws an Execution Error

*  If a graphql query execution fails the rails server doesn't know about it and doesn't log it
* add method to log output of the graphql server if it returns a result hash with an "errors" key

#67 