### PR TITLE
Changinge external id to string

### DIFF
--- a/app/graphql/mutations/create_news_item.rb
+++ b/app/graphql/mutations/create_news_item.rb
@@ -5,7 +5,7 @@ module Mutations
     argument :force_create, Boolean, required: false
     argument :author, String, required: false
     argument :title, String, required: false
-    argument :external_id, Integer, required: false
+    argument :external_id, String, required: false
     argument :full_version, Boolean, required: false
     argument :characters_to_be_shown, Integer, required: false
     argument :news_type, String, required: false

--- a/app/graphql/types/news_item_type.rb
+++ b/app/graphql/types/news_item_type.rb
@@ -5,7 +5,7 @@ module Types
     field :id, ID, null: true
     field :settings, SettingType, null: true
     field :title, String, null: true
-    field :external_id, Integer, null: true
+    field :external_id, String, null: true
     field :author, String, null: true
     field :full_version, Boolean, null: true
     field :characters_to_be_shown, String, null: true

--- a/app/models/data_resources/news_item.rb
+++ b/app/models/data_resources/news_item.rb
@@ -49,6 +49,6 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  data_provider_id       :integer
-#  external_id            :bigint
+#  external_id            :text(65535)
 #  title                  :string(255)
 #

--- a/db/migrate/20200511112404_change_externalid_to_string_for_newsitem.rb
+++ b/db/migrate/20200511112404_change_externalid_to_string_for_newsitem.rb
@@ -1,0 +1,5 @@
+class ChangeExternalidToStringForNewsitem < ActiveRecord::Migration[5.2]
+  def change
+    change_column :news_items, :external_id, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_11_090113) do
+ActiveRecord::Schema.define(version: 2020_05_11_112404) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -210,7 +210,7 @@ ActiveRecord::Schema.define(version: 2019_10_11_090113) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "data_provider_id"
-    t.bigint "external_id"
+    t.text "external_id"
     t.string "title"
   end
 

--- a/spec/factories/news_items.rb
+++ b/spec/factories/news_items.rb
@@ -27,6 +27,6 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  data_provider_id       :integer
-#  external_id            :bigint
+#  external_id            :text(65535)
 #  title                  :string(255)
 #

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -23,6 +23,6 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  data_provider_id       :integer
-#  external_id            :bigint
+#  external_id            :text(65535)
 #  title                  :string(255)
 #


### PR DESCRIPTION
Über die RSS Feed ist nun manchmal die externalD identisch zur Überschrift der News und damit ein Text und nicht zwingend immer eine Zahl