### PR TITLE
Fix for Doorkeeper update 5.1.1

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,7 +18,10 @@ class Users::SessionsController < Devise::SessionsController
         return render json: {
           success: true,
           user: resource,
-          applications: resource.oauth_applications,
+          applications: resource.oauth_applications.as_json(
+            only:[:name, :id, :created_at],
+            methods: [:uid, :secret, :owner_id, :owner_type]
+          ),
           roles: resource.try(:data_provider).try(:roles)
         }
       end


### PR DESCRIPTION
in Doorkeeper 5.1.1. `to_json` has been restricted for an oauth_application.
We extend the response here as we need them in our external services like cms or json importer