### PR TITLE
Implement model and mutation for AppUserContents

### DIFF
--- a/app/controllers/app_user_contents_controller.rb
+++ b/app/controllers/app_user_contents_controller.rb
@@ -39,7 +39,10 @@ class AppUserContentsController < ApplicationController
 
     respond_to do |format|
       if @app_user_content.save
-        format.html { redirect_to @app_user_content, notice: "App User Content was successfully created." }
+        format.html do
+          redirect_to @app_user_content,
+                      notice: "App User Content was successfully created."
+        end
         format.json { render :show, status: :created, location: @app_user_content }
       else
         format.html { render :new }
@@ -53,7 +56,10 @@ class AppUserContentsController < ApplicationController
   def update
     respond_to do |format|
       if @app_user_content.update(app_user_content_params)
-        format.html { redirect_to @app_user_content, notice: "App User Content was successfully updated." }
+        format.html do
+          redirect_to @app_user_content,
+                      notice: "App User Content was successfully updated."
+        end
         format.json { render :show, status: :ok, location: @app_user_content }
       else
         format.html { render :edit }
@@ -67,7 +73,10 @@ class AppUserContentsController < ApplicationController
   def destroy
     @app_user_content.destroy
     respond_to do |format|
-      format.html { redirect_to app_user_contents_url, notice: "App User Content was successfully destroyed." }
+      format.html do
+        redirect_to app_user_contents_url,
+                    notice: "App User Content was successfully destroyed."
+      end
       format.json { head :no_content }
     end
   end

--- a/app/controllers/app_user_contents_controller.rb
+++ b/app/controllers/app_user_contents_controller.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class AppUserContentsController < ApplicationController
+  layout "doorkeeper/admin"
+
+  before_action :authenticate_user!
+  before_action :authenticate_admin
+
+  before_action :set_app_user_content, only: %i[show edit update destroy]
+
+  def authenticate_admin
+    render inline: "not allowed", status: 404 unless current_user.admin_role?
+  end
+
+  # GET /app_user_contents
+  # GET /app_user_contents.json
+  def index
+    @app_user_contents = AppUserContent.all
+  end
+
+  # GET /app_user_contents/1
+  # GET /app_user_contents/1.json
+  def show
+  end
+
+  # GET /app_user_contents/new
+  def new
+    @app_user_content = AppUserContent.new
+  end
+
+  # GET /app_user_contents/1/edit
+  def edit
+  end
+
+  # POST /app_user_contents
+  # POST /app_user_contents.json
+  def create
+    @app_user_content = AppUserContent.new(app_user_content_params)
+
+    respond_to do |format|
+      if @app_user_content.save
+        format.html { redirect_to @app_user_content, notice: "App User Content was successfully created." }
+        format.json { render :show, status: :created, location: @app_user_content }
+      else
+        format.html { render :new }
+        format.json { render json: @app_user_content.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /app_user_contents/1
+  # PATCH/PUT /app_user_contents/1.json
+  def update
+    respond_to do |format|
+      if @app_user_content.update(app_user_content_params)
+        format.html { redirect_to @app_user_content, notice: "App User Content was successfully updated." }
+        format.json { render :show, status: :ok, location: @app_user_content }
+      else
+        format.html { render :edit }
+        format.json { render json: @app_user_content.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /app_user_contents/1
+  # DELETE /app_user_contents/1.json
+  def destroy
+    @app_user_content.destroy
+    respond_to do |format|
+      format.html { redirect_to app_user_contents_url, notice: "App User Content was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_app_user_content
+      @app_user_content = AppUserContent.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def app_user_content_params
+      params.require(:app_user_content).permit(:data_source, :data_type, :content)
+    end
+end

--- a/app/graphql/mutations/create_app_user_content.rb
+++ b/app/graphql/mutations/create_app_user_content.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateAppUserContent < BaseMutation
+    argument :data_source, String, required: false
+    argument :data_type, String, required: false
+    argument :content, String, required: false
+
+    type Types::AppUserContentType
+
+    def resolve(**params)
+      app_user_content = AppUserContent.create(params)
+      resource_or_error_message(app_user_content)
+    end
+
+    private
+
+      def resource_or_error_message(record)
+        if record.valid?
+          record
+        else
+          GraphQL::ExecutionError.new("Invalid input: #{record.errors.full_messages.join(", ")}")
+        end
+      end
+  end
+end

--- a/app/graphql/types/app_user_content_type.rb
+++ b/app/graphql/types/app_user_content_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class AppUserContentType < Types::BaseObject
+    field :id, ID, null: true
+    field :data_source, String, null: true
+    field :data_type, String, null: true
+    field :content, String, null: true
+    field :updated_at, String, null: true
+    field :created_at, String, null: true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,10 +2,14 @@
 
 module Types
   class MutationType < Types::BaseObject
+    # creations
     field :create_news_item, mutation: Mutations::CreateNewsItem
     field :create_tour, mutation: Mutations::CreateTour
     field :create_event_record, mutation: Mutations::CreateEventRecord
     field :create_point_of_interest, mutation: Mutations::CreatePointOfInterest
+    field :create_app_user_content, mutation: Mutations::CreateAppUserContent
+
+    # destroys
     field :destroy_record, mutation: Mutations::DestroyRecord
   end
 end

--- a/app/models/app_user_content.rb
+++ b/app/models/app_user_content.rb
@@ -1,0 +1,14 @@
+class AppUserContent < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: app_user_contents
+#
+#  id          :bigint           not null, primary key
+#  content     :text(65535)
+#  data_type   :string(255)
+#  data_source :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/app/models/app_user_content.rb
+++ b/app/models/app_user_content.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppUserContent < ApplicationRecord
 end
 

--- a/app/models/app_user_content.rb
+++ b/app/models/app_user_content.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AppUserContent < ApplicationRecord
+  validates_presence_of :content, :data_type, :data_source
 end
 
 # == Schema Information

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -23,7 +23,7 @@
 
 <div class="form-group">
   <%= f.label :role, "Rolle" %>
-  <%= f.select :role, [["Nutzer", :user], ["Admin", :admin]], class: "form-control" %>
+  <%= f.select :role, [["Nutzer", :user], ["Admin", :admin]], {}, class: "form-control" %>
 </div>
 
 <h2>Passwort</h2>
@@ -216,6 +216,7 @@
   <% end %>
 <% end %>
 
-<p>
-  <%= f.submit t("doorkeeper.applications.buttons.submit"), class: "btn btn-primar" %>
-</p>
+<div class="form-group">
+  <%= f.submit t("doorkeeper.applications.buttons.submit"), class: "btn btn-primary" %>
+  <%= link_to t('doorkeeper.applications.buttons.cancel'), accounts_path, class: "btn btn-default" %>
+</div>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div class="col">
     <h1>Nutzer bearbeiten</h1>
+
     <%= form_for @user, url: account_path(@user), method: :patch, html: { class: 'form-horizontal', role: 'form' } do |f| %>
       <%= render partial: 'form', locals: { f: f } %>
     <% end %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -2,7 +2,7 @@
   <div class="col">
     <h1>Nutzerverwaltung</h1>
 
-    <p><%= link_to "neuen Nutzer erstellen", new_account_path, class: 'btn btn-success' %></p>
+    <p><%= link_to "Neuen Nutzer erstellen", new_account_path, class: 'btn btn-success' %></p>
 
     <table class="table table-striped">
       <thead>
@@ -44,8 +44,12 @@
                 <%= user.try(:data_provider).try(:role_event_record) %>
               </span>
             </td>
-            <td class="align-middle" style="width: 70px"><%= link_to t('doorkeeper.applications.buttons.edit'), edit_account_path(user), class: 'btn btn-sm btn-outline-secondary' %></td>
-            <td class="align-middle" style="width: 70px"><%= link_to "Delete", account_path(user), method: :delete, class: 'btn btn-sm btn-outline-danger', data: { confirm: "Sind sie sicher?" } %></td>
+            <td class="align-middle" style="width: 70px">
+              <%= link_to t('doorkeeper.applications.buttons.edit'), edit_account_path(user), class: 'btn btn-sm btn-outline-secondary' %>
+            </td>
+            <td class="align-middle" style="width: 70px">
+              <%= link_to "Destroy", account_path(user), method: :delete, class: 'btn btn-sm btn-outline-danger', data: { confirm: "Sind sie sicher?" } %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div class="col">
-    <h1>Neuen Nutzer anlegen</h1>
+    <h1>Nutzer anlegen</h1>
+
     <%= form_for @user, url: accounts_path, method: :post, html: { class: 'form-horizontal', role: 'form'} do |f| %>
       <%= render partial: 'form', locals: { f: f } %>
     <% end %>

--- a/app/views/app_user_contents/_app_user_content.json.jbuilder
+++ b/app/views/app_user_contents/_app_user_content.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! app_user_content, :id, :data_type, :data_source, :content, :created_at, :updated_at
+json.url app_user_content_url(app_user_content, format: :json)

--- a/app/views/app_user_contents/_app_user_content.json.jbuilder
+++ b/app/views/app_user_contents/_app_user_content.json.jbuilder
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 json.extract! app_user_content, :id, :data_type, :data_source, :content, :created_at, :updated_at
 json.url app_user_content_url(app_user_content, format: :json)

--- a/app/views/app_user_contents/_form.html.erb
+++ b/app/views/app_user_contents/_form.html.erb
@@ -1,0 +1,60 @@
+<%= form_with(model: app_user_content, local: true) do |form| %>
+  <%= form.hidden_field :content %>
+
+  <% if app_user_content.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(app_user_content.errors.count, "error") %> prohibited this app_user_content from being saved:
+      </h2>
+
+      <ul>
+        <% app_user_content.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= form.label :data_source %>
+    <%= form.text_field :data_source, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :data_type %>
+    <%= form.select :data_type, [["JSON", "json"]], {}, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :content %>
+    <div id="code_editor" style="height: 400px;"></div>
+  </div>
+
+  <div class="form-group">
+    <%= form.submit t("doorkeeper.applications.buttons.submit"), class: "btn btn-primary" %>
+    <%= link_to t('doorkeeper.applications.buttons.cancel'), app_user_contents_path, class: "btn btn-default" %>
+  </div>
+<% end %>
+
+<script>
+  $(function () {
+    var container = document.getElementById("code_editor")
+    var options = {
+      mode: 'code',
+      <% if app_user_content.data_type == "json" %>
+        modes: ['code', 'tree'],
+      <% end %>
+      onChangeText: function(jsonString) {
+        $("#app_user_content_content").val(jsonString)
+      }
+    }
+    var editor = new JSONEditor(container, options)
+
+    <% content = app_user_content.content.to_s.html_safe %>
+    <% if app_user_content.data_type == "html" %>
+      editor.setText("<%= escape_javascript(content) %>")
+    <% else %>
+      editor.set(<%= content %>)
+    <% end %>
+  });
+</script>

--- a/app/views/app_user_contents/edit.html.erb
+++ b/app/views/app_user_contents/edit.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="col">
+    <h1>App User Content bearbeiten</h1>
+
+    <%= render 'form', app_user_content: @app_user_content %>
+  </div>
+</div>

--- a/app/views/app_user_contents/index.html.erb
+++ b/app/views/app_user_contents/index.html.erb
@@ -1,0 +1,31 @@
+<div class="row">
+  <div class="col">
+    <h1>App User Contents</h1>
+
+    <p><%= link_to 'New App User Content', new_app_user_content_path, class: "btn btn-success" %></p>
+
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Source</th>
+          <th>Type</th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @app_user_contents.each do |app_user_content| %>
+          <tr>
+            <td class="align-middle"><%= app_user_content.id %></td>
+            <td class="align-middle"><%= link_to app_user_content.data_source, app_user_content_path(app_user_content) %></td>
+            <td class="align-middle"><%= app_user_content.data_type.upcase %></td>
+            <td class="align-middle" style="width: 70px"><%= link_to 'Edit', edit_app_user_content_path(app_user_content), class: 'btn btn-sm btn-outline-secondary' %></td>
+            <td class="align-middle" style="width: 70px"><%= link_to 'Destroy', app_user_content, method: :delete,class: 'btn btn-sm btn-outline-danger', data: { confirm: 'Are you sure?' } %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/app_user_contents/index.json.jbuilder
+++ b/app/views/app_user_contents/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @app_user_contents, partial: "app_user_contents/app_user_content", as: :app_user_content

--- a/app/views/app_user_contents/index.json.jbuilder
+++ b/app/views/app_user_contents/index.json.jbuilder
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 json.array! @app_user_contents, partial: "app_user_contents/app_user_content", as: :app_user_content

--- a/app/views/app_user_contents/new.html.erb
+++ b/app/views/app_user_contents/new.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="col">
+    <h1>App User Content anlegen</h1>
+
+    <%= render 'form', app_user_content: @app_user_content %>
+  </div>
+</div>

--- a/app/views/app_user_contents/show.html.erb
+++ b/app/views/app_user_contents/show.html.erb
@@ -1,0 +1,49 @@
+<div class="row">
+  <div class="col">
+    <h1>App User Content</h1>
+
+    <div class="form-group">
+      <label>Data source</label>
+      <div><code><%= @app_user_content.data_source %></code></div>
+    </div>
+
+    <div class="form-group">
+      <label>Data type</label>
+      <div><code><%= @app_user_content.data_type %></code></div>
+    </div>
+
+    <div class="form-group">
+      <label>Content</label>
+      <div id="code_editor" style="height: 400px;"></div>
+    </div>
+
+    <div class="form-group">
+      <%= link_to t("doorkeeper.applications.buttons.edit"), edit_app_user_content_path(@app_user_content), class: "btn btn-primary" %>
+      <%= link_to t('doorkeeper.applications.buttons.back'), app_user_contents_path, class: "btn btn-default" %>
+    </div>
+  </div>
+</div>
+
+<script>
+  $(function () {
+    var container = document.getElementById("code_editor")
+    var options = {
+      mode: 'code',
+      onEditable: function (node) {
+        if (!node.path) {
+          // In modes code and text, node is empty: no path, field, or value
+          // returning false makes the text area read-only
+          return false;
+        }
+      },
+    }
+    var editor = new JSONEditor(container, options)
+
+    <% content = @app_user_content.content.to_s.html_safe %>
+    <% if @app_user_content.data_type == "html" %>
+      editor.setText("<%= escape_javascript(content) %>")
+    <% else %>
+      editor.set(<%= content %>)
+    <% end %>
+  });
+</script>

--- a/app/views/app_user_contents/show.json.jbuilder
+++ b/app/views/app_user_contents/show.json.jbuilder
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 json.partial! "app_user_contents/app_user_content", app_user_content: @app_user_content

--- a/app/views/app_user_contents/show.json.jbuilder
+++ b/app/views/app_user_contents/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "app_user_contents/app_user_content", app_user_content: @app_user_content

--- a/app/views/layouts/doorkeeper/admin.html.erb
+++ b/app/views/layouts/doorkeeper/admin.html.erb
@@ -12,7 +12,7 @@
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-5">
-  <%= link_to "SmartVillage Server", root_path, class: 'navbar-brand' %>
+  <%= link_to "Smart Village App - Main-Server", root_path, class: 'navbar-brand' %>
 
   <div class="collapse navbar-collapse">
     <ul class="navbar-nav mr-auto">
@@ -22,7 +22,7 @@
         </li>
 
         <li class="nav-item">
-          <%= link_to "StaticContents", static_contents_path, class: 'nav-link' %>
+          <%= link_to "Static Contents", static_contents_path, class: 'nav-link' %>
         </li>
       <% end %>
       <li class="nav-item <%= 'active' if request.path == oauth_applications_path %>">
@@ -30,11 +30,11 @@
       </li>
       <% unless current_user.admin_role? %>
         <li class="nav-item">
-            <%= link_to "Data Provider", edit_data_provider_path, class: 'nav-link' %>
+          <%= link_to "Data Provider", edit_data_provider_path, class: 'nav-link' %>
         </li>
       <% end %>
       <li class="nav-item">
-          <%= link_to "Sign out (#{current_user.email})", destroy_user_session_path, class: 'nav-link', method: :delete %>
+        <%= link_to "Sign out (#{current_user.email})", destroy_user_session_path, class: 'nav-link', method: :delete %>
       </li>
     </ul>
   </div>

--- a/app/views/layouts/doorkeeper/admin.html.erb
+++ b/app/views/layouts/doorkeeper/admin.html.erb
@@ -24,6 +24,10 @@
         <li class="nav-item">
           <%= link_to "Static Contents", static_contents_path, class: 'nav-link' %>
         </li>
+
+        <li class="nav-item">
+          <%= link_to "App User Contents", app_user_contents_path, class: 'nav-link' %>
+        </li>
       <% end %>
       <li class="nav-item <%= 'active' if request.path == oauth_applications_path %>">
         <%= link_to t('doorkeeper.layouts.admin.nav.applications'), oauth_applications_path, class: 'nav-link' %>

--- a/app/views/oauth/applications/_delete_form.html.erb
+++ b/app/views/oauth/applications/_delete_form.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag oauth_application_path(application), method: :delete do %>
-  <%= submit_tag t('doorkeeper.applications.buttons.destroy'), onclick: "return confirm('#{ t('doorkeeper.applications.confirmations.destroy') }')", class: 'btn btn-sm btn-outline-danger' %>
+  <%= submit_tag t('doorkeeper.applications.buttons.destroy'), onclick: "return confirm('#{ t('doorkeeper.applications.confirmations.destroy') }')", class: 'btn btn-danger' %>
 <% end %>

--- a/app/views/oauth/applications/_form.html.erb
+++ b/app/views/oauth/applications/_form.html.erb
@@ -56,8 +56,8 @@
     </small>
   </div>
 
-  <p>
+  <div class="form-group">
     <%= f.submit t('doorkeeper.applications.buttons.submit'), class: "btn btn-primary" %>
     <%= link_to t('doorkeeper.applications.buttons.cancel'), oauth_applications_path, class: "btn btn-default" %>
-  </p>
+  </div>
 <% end %>

--- a/app/views/oauth/applications/edit.html.erb
+++ b/app/views/oauth/applications/edit.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div class="col">
-    <h1><%= t('.title') %></h1>
+    <h1>Application bearbeiten</h1>
+
     <%= render 'form', application: @application %>
   </div>
 </div>

--- a/app/views/oauth/applications/new.html.erb
+++ b/app/views/oauth/applications/new.html.erb
@@ -1,5 +1,7 @@
-<div class="page-header">
-  <h1><%= t('.title') %></h1>
-</div>
+<div class="row">
+  <div class="col">
+    <h1>Application anlegen</h1>
 
-<%= render 'form', application: @application %>
+    <%= render 'form', application: @application %>
+  </div>
+</div>

--- a/app/views/oauth/applications/show.html.erb
+++ b/app/views/oauth/applications/show.html.erb
@@ -1,39 +1,50 @@
 <div class="row">
   <div class="col">
-    <h2><%= t('.title', name: @application.name) %></h2>
+    <h1><%= @application.name %></h1>
 
-    <h5><%= t('.application_id') %>:</h5>
-    <p><code><%= @application.uid %></code></p>
+    <div class="form-group">
+      <label><%= t('.application_id') %></label>
+      <div><code><%= @application.uid %></code></div>
+    </div>
 
-    <h5><%= t('.secret') %>:</h5>
-    <p><code><%= @application.secret %></code></p>
+    <div class="form-group">
+      <label><%= t('.secret') %></label>
+      <div><code><%= @application.secret %></code></div>
+    </div>
 
-    <h5><%= t('.scopes') %>:</h5>
-    <p><code><%= @application.scopes %></code></p>
+    <div class="form-group">
+      <label><%= t('.scopes') %></label>
+      <div><code><%= @application.scopes %></code></div>
+    </div>
 
-    <h5><%= t('.confidential') %>:</h5>
-    <p><code><%= @application.confidential %></code></p>
+    <div class="form-group">
+      <label><%= t('.confidential') %></label>
+      <div><code><%= @application.confidential %></code></div>
+    </div>
 
-    <h5><%= t('.callback_urls') %>:</h5>
+    <div class="form-group">
+      <label><%= t('.callback_urls') %></label>
+      <table class="table table-striped w-75">
+        <tbody>
+          <% @application.redirect_uri.split.each do |uri| %>
+            <tr>
+              <td class="align-middle"><code><%= uri %></code></td>
+              <td class="align-middle" style="width: 70px">
+                <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes), class: 'btn btn-success', target: '_blank' %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
 
-    <table class="table table-striped">
-      <tbody>
-        <% @application.redirect_uri.split.each do |uri| %>
-          <tr>
-            <td class="align-middle"><code><%= uri %></code></td>
-            <td class="align-middle" style="width: 70px"><%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes), class: 'btn btn-sm btn-success', target: '_blank' %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <div class="form-inline">
+      <div class="form-group">
+        <%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: "btn btn-primary" %>
+        &nbsp;
+        <%= render 'delete_form', application: @application %>
+        &nbsp;
+        <%= link_to t('doorkeeper.applications.buttons.cancel'), oauth_applications_path, class: "btn btn-default" %>
+      </div>
+    </div>
   </div>
-
-  <div class="col-3">
-    <h2><%= t('.actions') %></h2>
-
-    <p>
-      <%= link_to t('doorkeeper.applications.buttons.edit'), edit_oauth_application_path(@application), class: 'btn btn-sm btn-outline-primary' %>
-      <%= render 'delete_form', application: @application %>
-    </p>
-  </div>
-</div>

--- a/app/views/static_contents/_form.html.erb
+++ b/app/views/static_contents/_form.html.erb
@@ -3,40 +3,44 @@
 
   <% if static_content.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(static_content.errors.count, "error") %> prohibited this static_content from being saved:</h2>
+      <h2>
+        <%= pluralize(static_content.errors.count, "error") %> prohibited this static_content from being saved:
+      </h2>
 
       <ul>
-      <% static_content.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
+        <% static_content.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
       </ul>
     </div>
   <% end %>
 
   <div class="form-group">
     <%= form.label :name %>
-    <%= form.text_field :name, class: 'form-control' %>
+    <%= form.text_field :name, class: "form-control" %>
   </div>
 
   <div class="form-group">
     <%= form.label :data_type %>
-    <%= form.select :data_type, [["HTML", "html"], ["JSON", "json"]], class: 'form-control' %>
+    <%= form.select :data_type, [["HTML", "html"], ["JSON", "json"]], {}, class: "form-control" %>
   </div>
 
   <div class="form-group">
+    <%= form.label :content %>
     <div id="code_editor" style="height: 400px;"></div>
   </div>
 
-  <p>
-    <%= form.submit class: "btn btn-primary", id: "save_static_content" %>
-  </p>
+  <div class="form-group">
+    <%= form.submit t("doorkeeper.applications.buttons.submit"), class: "btn btn-primary" %>
+    <%= link_to t('doorkeeper.applications.buttons.cancel'), static_contents_path, class: "btn btn-default" %>
+  </div>
 <% end %>
 
 <script>
   $(function () {
-    const container = document.getElementById("code_editor")
-    const options = {
-      mode: "<%= static_content.data_type == 'html' ? 'code' : 'tree' %>",
+    var container = document.getElementById("code_editor")
+    var options = {
+      mode: 'code',
       <% if static_content.data_type == "json" %>
         modes: ['code', 'tree'],
       <% end %>
@@ -44,11 +48,13 @@
         $("#static_content_content").val(jsonString)
       }
     }
-    const editor = new JSONEditor(container, options)
+    var editor = new JSONEditor(container, options)
+
+    <% content = static_content.content.to_s.html_safe %>
     <% if static_content.data_type == "html" %>
-      editor.setText("<%= escape_javascript(static_content.content.to_s.html_safe) %>")
+      editor.setText("<%= escape_javascript(content) %>")
     <% else %>
-      editor.set(<%= static_content.content.to_s.html_safe %>)
+      editor.set(<%= content %>)
     <% end %>
   });
 </script>

--- a/app/views/static_contents/edit.html.erb
+++ b/app/views/static_contents/edit.html.erb
@@ -1,6 +1,7 @@
-<h1>Editing Static Content</h1>
+<div class="row">
+  <div class="col">
+    <h1>Static Content bearbeiten</h1>
 
-<%= render 'form', static_content: @static_content %>
-
-<%= link_to 'Show', @static_content %> |
-<%= link_to 'Back', static_contents_path %>
+    <%= render 'form', static_content: @static_content %>
+  </div>
+</div>

--- a/app/views/static_contents/index.html.erb
+++ b/app/views/static_contents/index.html.erb
@@ -2,7 +2,6 @@
   <div class="col">
     <h1>Static Contents</h1>
 
-    <p id="notice"><%= notice %></p>
     <p><%= link_to 'New Static Content', new_static_content_path, class: "btn btn-success" %></p>
 
     <table class="table table-striped">
@@ -11,24 +10,22 @@
           <th>ID</th>
           <th>Name</th>
           <th>Type</th>
-          <th colspan="3"></th>
+          <th></th>
+          <th></th>
         </tr>
       </thead>
 
       <tbody>
         <% @static_contents.each do |static_content| %>
           <tr>
-            <td><%= static_content.id %></td>
-            <td><%= static_content.name %></td>
-            <td><%= static_content.data_type.upcase %></td>
-            <td><%= link_to 'Show', static_content, class: 'btn btn-sm btn-outline-secondary' %></td>
-            <td><%= link_to 'Edit', edit_static_content_path(static_content), class: 'btn btn-sm btn-outline-secondary' %></td>
-            <td><%= link_to 'Destroy', static_content, method: :delete,class: 'btn btn-sm btn-outline-danger', data: { confirm: 'Are you sure?' } %></td>
+            <td class="align-middle"><%= static_content.id %></td>
+            <td class="align-middle"><%= link_to static_content.name, static_content_path(static_content) %></td>
+            <td class="align-middle"><%= static_content.data_type.upcase %></td>
+            <td class="align-middle" style="width: 70px"><%= link_to 'Edit', edit_static_content_path(static_content), class: 'btn btn-sm btn-outline-secondary' %></td>
+            <td class="align-middle" style="width: 70px"><%= link_to 'Destroy', static_content, method: :delete,class: 'btn btn-sm btn-outline-danger', data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>
     </table>
   </div>
 </div>
-
-

--- a/app/views/static_contents/new.html.erb
+++ b/app/views/static_contents/new.html.erb
@@ -1,5 +1,7 @@
-<h1>New Static Content</h1>
+<div class="row">
+  <div class="col">
+    <h1>Static Content anlegen</h1>
 
-<%= render 'form', static_content: @static_content %>
-
-<%= link_to 'Back', static_contents_path %>
+    <%= render 'form', static_content: @static_content %>
+  </div>
+</div>

--- a/app/views/static_contents/show.html.erb
+++ b/app/views/static_contents/show.html.erb
@@ -1,19 +1,44 @@
-<p id="notice"><%= notice %></p>
+<div class="row">
+  <div class="col">
+    <h1><%= @static_content.name %></h1>
 
-<p>
-  <strong>Name:</strong>
-  <%= @static_content.name %>
-</p>
+    <div class="form-group">
+      <label>Data type</label>
+      <div><code><%= @static_content.data_type %></code></div>
+    </div>
 
-<p>
-  <strong>Data type:</strong>
-  <%= @static_content.data_type %>
-</p>
+    <div class="form-group">
+      <label>Content</label>
+      <div id="code_editor" style="height: 400px;"></div>
+    </div>
 
-<p>
-  <strong>Content:</strong>
-  <%= @static_content.content %>
-</p>
+    <div class="form-group">
+      <%= link_to t("doorkeeper.applications.buttons.edit"), edit_static_content_path(@static_content), class: "btn btn-primary" %>
+      <%= link_to t('doorkeeper.applications.buttons.back'), static_contents_path, class: "btn btn-default" %>
+    </div>
+  </div>
+</div>
 
-<%= link_to 'Edit', edit_static_content_path(@static_content) %> |
-<%= link_to 'Back', static_contents_path %>
+<script>
+  $(function () {
+    var container = document.getElementById("code_editor")
+    var options = {
+      mode: 'code',
+      onEditable: function (node) {
+        if (!node.path) {
+          // In modes code and text, node is empty: no path, field, or value
+          // returning false makes the text area read-only
+          return false;
+        }
+      },
+    }
+    var editor = new JSONEditor(container, options)
+
+    <% content = @static_content.content.to_s.html_safe %>
+    <% if @static_content.data_type == "html" %>
+      editor.setText("<%= escape_javascript(content) %>")
+    <% else %>
+      editor.set(<%= content %>)
+    <% end %>
+  });
+</script>

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -26,6 +26,7 @@ en:
         destroy: 'Destroy'
         submit: 'Submit'
         cancel: 'Cancel'
+        back: 'Back'
         authorize: 'Authorize'
       form:
         error: 'Whoops! Check your form for possible errors'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
+  resources :app_user_contents
   resources :static_contents
   get "data_provider", to: "data_provider#show", as: :data_provider
   get "data_provider/edit", as: :edit_data_provider
@@ -6,7 +9,7 @@ Rails.application.routes.draw do
   resources :accounts
 
   use_doorkeeper do
-    controllers :applications => "oauth/applications"
+    controllers applications: "oauth/applications"
   end
 
   devise_for :users, controllers: {
@@ -14,7 +17,7 @@ Rails.application.routes.draw do
   }
 
   # if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+  mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
   # end
 
   post "/graphql", to: "graphql#execute"

--- a/db/migrate/20200526144646_create_app_user_contents.rb
+++ b/db/migrate/20200526144646_create_app_user_contents.rb
@@ -1,0 +1,11 @@
+class CreateAppUserContents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :app_user_contents do |t|
+      t.text :content
+      t.string :data_type
+      t.string :data_source
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_112404) do
+ActiveRecord::Schema.define(version: 2020_05_26_144646) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -33,6 +33,14 @@ ActiveRecord::Schema.define(version: 2020_05_11_112404) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
+  end
+
+  create_table "app_user_contents", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "content"
+    t.string "data_type"
+    t.string "data_source"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "attractions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,7 +14,9 @@ services:
     volumes:
       - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     labels:
-      - traefik.frontend.rule=Host:server.localhost
+      - traefik.enable=true
+      - traefik.docker.network=public
+      - traefik.frontend.rule=Host:server.smart-village.docker.localhost
 
   db:
     volumes:

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -33,6 +33,15 @@ input AddressInput {
 
 scalar AnyPrimitive
 
+type AppUserContent {
+  content: String
+  createdAt: String
+  dataSource: String
+  dataType: String
+  id: ID
+  updatedAt: String
+}
+
 type Category {
   id: ID
   name: String
@@ -142,6 +151,7 @@ type EventRecord {
   regionId: String
   repeat: Boolean
   repeatDuration: RepeatDuration
+  settings: Setting
   tagList: [String!]
   title: String
   updatedAt: String
@@ -211,8 +221,9 @@ input MediaContentInput {
 }
 
 type Mutation {
+  createAppUserContent(content: String, dataSource: String, dataType: String): AppUserContent!
   createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
-  createNewsItem(address: AddressInput, author: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], externalId: Int, forceCreate: Boolean, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, showPublishDate: Boolean, sourceUrl: WebUrlInput, title: String): NewsItem!
+  createNewsItem(address: AddressInput, author: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], externalId: String, forceCreate: Boolean, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, showPublishDate: Boolean, sourceUrl: WebUrlInput, title: String): NewsItem!
   createPointOfInterest(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, openingHours: [OpeningHourInput!], operatingCompany: OperatingCompanyInput, priceInformations: [PriceInput!], tags: [String!], webUrls: [WebUrlInput!]): PointOfInterest!
   createTour(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, geometryTourData: [GeoLocationInput!], lengthKm: Int!, location: LocationInput, meansOfTransportation: String, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, operatingCompany: OperatingCompanyInput, tags: [String!], webUrls: [WebUrlInput!]): Tour!
   destroyRecord(externalId: Int, id: Int, recordType: String!): Destroy!
@@ -225,12 +236,13 @@ type NewsItem {
   contentBlocks: [ContentBlock!]
   createdAt: String
   dataProvider: DataProvider
-  externalId: Int
+  externalId: String
   fullVersion: Boolean
   id: ID
   newsType: String
   publicationDate: String
   publishedAt: String
+  settings: Setting
   showPublishDate: Boolean
   sourceUrl: WebUrl
   title: String
@@ -302,6 +314,7 @@ type PointOfInterest {
   openingHours: [OpeningHour!]
   operatingCompany: OperatingCompany
   priceInformations: [Price!]
+  settings: Setting
   tagList: [String!]
   updatedAt: String
   webUrls: [WebUrl!]
@@ -394,6 +407,12 @@ input RepeatDurationInput {
   startDate: String
 }
 
+type Setting {
+  alwaysRecreateOnImport: String
+  displayOnlySummary: String
+  onlySummaryLinkText: String
+}
+
 type Tour {
   active: Boolean
   addresses: [Address!]
@@ -412,6 +431,7 @@ type Tour {
   name: String
   operatingCompany: OperatingCompany
   regions: [Region!]
+  settings: Setting
   tags: String
   updatedAt: String
   webUrls: [WebUrl!]

--- a/public/schema.json
+++ b/public/schema.json
@@ -764,6 +764,20 @@
               "deprecationReason": null
             },
             {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tagList",
               "description": null,
               "args": [
@@ -836,6 +850,61 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Setting",
+          "description": null,
+          "fields": [
+            {
+              "name": "alwaysRecreateOnImport",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "displayOnlySummary",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onlySummaryLinkText",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2485,6 +2554,20 @@
               "deprecationReason": null
             },
             {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tagList",
               "description": null,
               "args": [
@@ -2975,7 +3058,7 @@
               ],
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -3046,6 +3129,20 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -3581,6 +3678,20 @@
               "deprecationReason": null
             },
             {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tags",
               "description": null,
               "args": [
@@ -3798,6 +3909,53 @@
           "name": "Mutation",
           "description": null,
           "fields": [
+            {
+              "name": "createAppUserContent",
+              "description": null,
+              "args": [
+                {
+                  "name": "dataSource",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "dataType",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "content",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AppUserContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "createEventRecord",
               "description": null,
@@ -4110,7 +4268,7 @@
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -5681,6 +5839,103 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AppUserContent",
+          "description": null,
+          "fields": [
+            {
+              "name": "content",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dataSource",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dataType",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,6 @@
 type AccessibilityInformation {
   description: String
-  id: ID!
+  id: ID
   types: String
   urls: [WebUrl!]
 }
@@ -16,7 +16,7 @@ type Address {
   city: String
   geoLocation: GeoLocation
   id: ID
-  kind: String!
+  kind: String
   street: String
   zip: String
 }
@@ -25,25 +25,44 @@ input AddressInput {
   addition: String
   city: String
   geoLocation: GeoLocationInput
+  id: Int
   kind: String
   street: String
   zip: String
 }
 
+scalar AnyPrimitive
+
+type AppUserContent {
+  content: String
+  createdAt: String
+  dataSource: String
+  dataType: String
+  id: ID
+  updatedAt: String
+}
+
+type Category {
+  id: ID
+  name: String
+  pointsOfInterestCount: Int
+  toursCount: Int
+}
+
 type Certificate {
-  id: ID!
+  id: ID
   name: String
 }
 
 input CertificateInput {
-  name: String!
+  name: String
 }
 
 type Contact {
   email: String
-  fax: Boolean
+  fax: String
   firstName: String
-  id: ID!
+  id: ID
   lastName: String
   phone: String
   webUrls: [WebUrl!]
@@ -61,7 +80,7 @@ input ContactInput {
 type ContentBlock {
   body: String
   createdAt: String
-  id: ID!
+  id: ID
   intro: String
   mediaContents: [MediaContent!]
   title: String
@@ -79,23 +98,15 @@ type DataProvider {
   address: Address
   contact: Contact
   description: String
-  id: ID!
+  id: ID
   logo: WebUrl
-  name: String
-}
-
-input DataProviderInput {
-  address: AddressInput
-  contact: ContactInput
-  description: String
-  logo: WebUrlInput
   name: String
 }
 
 type Date {
   dateEnd: String
   dateStart: String
-  id: ID!
+  id: ID
   timeDescription: String
   timeEnd: String
   timeStart: String
@@ -113,26 +124,36 @@ input DateInput {
   weekday: String
 }
 
+type Destroy {
+  id: Int
+  status: String
+  statusCode: Int
+}
+
 type EventRecord {
   accessibilityInformation: AccessibilityInformation
-  addresses: [Address!]!
-  categoryId: Int!
+  addresses: [Address!]
+  category: Category
   contacts: [Contact!]
   createdAt: String
   dataProvider: DataProvider
-  dates: [Date!]!
+  dates: [Date!]
   description: String
-  id: ID!
+  externalId: String
+  id: ID
+  listDate: String
   location: Location
   mediaContents: [MediaContent!]
   organizer: OperatingCompany
   parentId: Int
   priceInformations: [Price!]
+  region: Region
   regionId: String
   repeat: Boolean
   repeatDuration: RepeatDuration
+  settings: Setting
   tagList: [String!]
-  title: String!
+  title: String
   updatedAt: String
   urls: [WebUrl!]
 }
@@ -142,6 +163,8 @@ enum EventRecordsOrder {
   createdAt_DESC
   id_ASC
   id_DESC
+  listDate_ASC
+  listDate_DESC
   title_ASC
   title_DESC
   updatedAt_ASC
@@ -149,14 +172,14 @@ enum EventRecordsOrder {
 }
 
 type GeoLocation {
-  id: ID!
-  latitude: Float!
-  longitude: Float!
+  id: ID
+  latitude: Float
+  longitude: Float
 }
 
 input GeoLocationInput {
-  latitude: Float!
-  longitude: Float!
+  latitude: AnyPrimitive
+  longitude: AnyPrimitive
 }
 
 type Location {
@@ -165,8 +188,8 @@ type Location {
   geoLocation: GeoLocation
   id: ID
   name: String
-  regionId: Int
-  state: String!
+  regionName: String
+  state: String
 }
 
 input LocationInput {
@@ -174,17 +197,17 @@ input LocationInput {
   district: String
   geoLocation: GeoLocationInput
   name: String
-  regionId: Int
+  regionName: String
   state: String
 }
 
 type MediaContent {
-  captionText: String!
-  contentType: String!
+  captionText: String
+  contentType: String
   copyright: String
   height: Int
-  id: ID!
-  sourceUrl: WebUrl!
+  id: ID
+  sourceUrl: WebUrl
   width: Int
 }
 
@@ -192,16 +215,18 @@ input MediaContentInput {
   captionText: String
   contentType: String
   copyright: String
-  height: Int
+  height: AnyPrimitive
   sourceUrl: WebUrlInput
-  width: Int
+  width: AnyPrimitive
 }
 
 type Mutation {
-  createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categoryId: Int, contacts: [ContactInput!], dataProvider: DataProviderInput, dates: [DateInput!], description: String, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], regionId: Int, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
-  createNewsItem(address: AddressInput, author: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], dataProvider: DataProviderInput, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, sourceUrl: WebUrlInput): NewsItem!
-  createPointOfInterest(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categoryId: Int, certificates: [CertificateInput!], contact: ContactInput, dataProvider: DataProviderInput, description: String, location: LocationInput, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, openingHours: [OpeningHourInput!], operatingCompany: OperatingCompanyInput, prices: [PriceInput!], tags: String, webUrls: [WebUrlInput!]): PointOfInterest!
-  createTour(active: Boolean, addresses: [AddressInput!], categoryId: Int, contact: ContactInput, dataProvider: DataProviderInput, description: String, geometryTourData: [GeoLocationInput!], lengthKm: Int!, meansOfTransportation: String, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, operatingCompany: OperatingCompanyInput, tags: String, webUrls: [WebUrlInput!]): Tour!
+  createAppUserContent(content: String, dataSource: String, dataType: String): AppUserContent!
+  createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
+  createNewsItem(address: AddressInput, author: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], externalId: String, forceCreate: Boolean, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, showPublishDate: Boolean, sourceUrl: WebUrlInput, title: String): NewsItem!
+  createPointOfInterest(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, openingHours: [OpeningHourInput!], operatingCompany: OperatingCompanyInput, priceInformations: [PriceInput!], tags: [String!], webUrls: [WebUrlInput!]): PointOfInterest!
+  createTour(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, geometryTourData: [GeoLocationInput!], lengthKm: Int!, location: LocationInput, meansOfTransportation: String, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, operatingCompany: OperatingCompanyInput, tags: [String!], webUrls: [WebUrlInput!]): Tour!
+  destroyRecord(externalId: Int, id: Int, recordType: String!): Destroy!
 }
 
 type NewsItem {
@@ -211,13 +236,16 @@ type NewsItem {
   contentBlocks: [ContentBlock!]
   createdAt: String
   dataProvider: DataProvider
-  fullVersion: Boolean!
-  id: ID!
+  externalId: String
+  fullVersion: Boolean
+  id: ID
   newsType: String
   publicationDate: String
-  publishedAt: String!
-  showPublishDate: Boolean!
+  publishedAt: String
+  settings: Setting
+  showPublishDate: Boolean
   sourceUrl: WebUrl
+  title: String
   updatedAt: String
 }
 
@@ -226,6 +254,8 @@ enum NewsItemsOrder {
   createdAt_DESC
   id_ASC
   id_DESC
+  publishedAt_ASC
+  publishedAt_DESC
   updatedAt_ASC
   updatedAt_DESC
 }
@@ -234,7 +264,7 @@ type OpeningHour {
   dateFrom: String
   dateTo: String
   description: String
-  id: ID!
+  id: ID
   open: Boolean
   sortNumber: Int
   timeFrom: String
@@ -256,40 +286,42 @@ input OpeningHourInput {
 type OperatingCompany {
   address: Address
   contact: Contact
-  id: ID!
+  id: ID
   name: String
 }
 
 input OperatingCompanyInput {
   address: AddressInput
   contact: ContactInput
-  name: String!
+  name: String
 }
 
 type PointOfInterest {
   accessibilityInformation: AccessibilityInformation
   active: Boolean
-  addresses: [Address!]!
-  categoryId: Int!
+  addresses: [Address!]
+  category: Category
   certificates: [Certificate!]
   contact: Contact
   createdAt: String
   dataProvider: DataProvider
   description: String
-  id: ID!
+  id: ID
   location: Location
   mediaContents: [MediaContent!]
   mobileDescription: String
-  name: String!
+  name: String
   openingHours: [OpeningHour!]
   operatingCompany: OperatingCompany
-  prices: [Price!]
-  tagList: String
+  priceInformations: [Price!]
+  settings: Setting
+  tagList: [String!]
   updatedAt: String
   webUrls: [WebUrl!]
 }
 
 enum PointsOfInterestOrder {
+  RAND
   createdAt_ASC
   createdAt_DESC
   id_ASC
@@ -318,7 +350,7 @@ type Price {
 input PriceInput {
   ageFrom: Int
   ageTo: Int
-  amount: Float
+  amount: AnyPrimitive
   category: String
   description: String
   groupPrice: Boolean
@@ -329,25 +361,43 @@ input PriceInput {
   name: String
 }
 
+type PublicHtmlFile {
+  content: String
+  name: String
+}
+
+type PublicJsonFile {
+  content: String!
+  name: String!
+}
+
 type Query {
+  categories: [Category!]!
   eventRecord(id: ID!): EventRecord!
-  eventRecords(limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int): [EventRecord]
+  eventRecords(limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
   newsItem(id: ID!): NewsItem!
-  newsItems(limit: Int, order: NewsItemsOrder = createdAt_DESC, skip: Int): [NewsItem]
+  newsItems(limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
   pointOfInterest(id: ID!): PointOfInterest!
-  pointsOfInterest(limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
+  pointsOfInterest(category: String, limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
+  publicHtmlFile(name: String!): PublicHtmlFile!
+  publicJsonFile(name: String!): PublicJsonFile!
   tour(id: ID!): Tour!
-  tours(limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
+  tours(category: String, limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
 }
 
 type Region {
-  name: String!
+  id: ID
+  name: String
+}
+
+input RegionInput {
+  name: String
 }
 
 type RepeatDuration {
   endDate: String
   everyYear: Boolean
-  id: ID!
+  id: ID
   startDate: String
 }
 
@@ -357,30 +407,38 @@ input RepeatDurationInput {
   startDate: String
 }
 
+type Setting {
+  alwaysRecreateOnImport: String
+  displayOnlySummary: String
+  onlySummaryLinkText: String
+}
+
 type Tour {
   active: Boolean
   addresses: [Address!]
-  categoryId: Int!
+  category: Category
   certificates: [Certificate!]
   contact: Contact
   createdAt: String
   dataProvider: DataProvider
   description: String
   geometryTourData: [GeoLocation!]!
-  id: ID!
+  id: ID
   lengthKm: Int
   meansOfTransportation: String
   mediaContents: [MediaContent!]
   mobileDescription: String
-  name: String!
+  name: String
   operatingCompany: OperatingCompany
   regions: [Region!]
+  settings: Setting
   tags: String
   updatedAt: String
   webUrls: [WebUrl!]
 }
 
 enum ToursOrder {
+  RAND
   createdAt_ASC
   createdAt_DESC
   id_ASC
@@ -393,8 +451,8 @@ enum ToursOrder {
 
 type WebUrl {
   description: String
-  id: ID!
-  url: String!
+  id: ID
+  url: String
 }
 
 input WebUrlInput {

--- a/schema.json
+++ b/schema.json
@@ -35,6 +35,32 @@
           "description": null,
           "fields": [
             {
+              "name": "categories",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Category",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "eventRecord",
               "description": null,
               "args": [
@@ -71,6 +97,16 @@
               "args": [
                 {
                   "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "take",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -175,7 +211,7 @@
                     "name": "NewsItemsOrder",
                     "ofType": null
                   },
-                  "defaultValue": "createdAt_DESC"
+                  "defaultValue": "publishedAt_DESC"
                 }
               ],
               "type": {
@@ -254,6 +290,16 @@
                     "ofType": null
                   },
                   "defaultValue": "createdAt_DESC"
+                },
+                {
+                  "name": "category",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -262,6 +308,68 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "PointOfInterest",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicHtmlFile",
+              "description": null,
+              "args": [
+                {
+                  "name": "name",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PublicHtmlFile",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicJsonFile",
+              "description": null,
+              "args": [
+                {
+                  "name": "name",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PublicJsonFile",
                   "ofType": null
                 }
               },
@@ -332,6 +440,16 @@
                     "ofType": null
                   },
                   "defaultValue": "createdAt_DESC"
+                },
+                {
+                  "name": "category",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -402,19 +520,15 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Address",
-                      "ofType": null
-                    }
+                    "kind": "OBJECT",
+                    "name": "Address",
+                    "ofType": null
                   }
                 }
               },
@@ -422,19 +536,15 @@
               "deprecationReason": null
             },
             {
-              "name": "categoryId",
+              "name": "category",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Category",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -524,13 +634,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -592,13 +698,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -640,7 +742,7 @@
               "deprecationReason": null
             },
             {
-              "name": "prices",
+              "name": "priceInformations",
               "description": null,
               "args": [
 
@@ -662,15 +764,37 @@
               "deprecationReason": null
             },
             {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tagList",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -726,6 +850,61 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Setting",
+          "description": null,
+          "fields": [
+            {
+              "name": "alwaysRecreateOnImport",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "displayOnlySummary",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onlySummaryLinkText",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -797,13 +976,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -856,13 +1031,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -874,13 +1045,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -892,13 +1059,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -918,6 +1081,75 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Category",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pointsOfInterestCount",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "toursCount",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1007,14 +1239,14 @@
               "deprecationReason": null
             },
             {
-              "name": "regionId",
+              "name": "regionName",
               "description": null,
               "args": [
 
               ],
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -1027,13 +1259,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1100,13 +1328,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1173,13 +1397,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1191,13 +1411,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1237,7 +1453,7 @@
               ],
               "type": {
                 "kind": "SCALAR",
-                "name": "Boolean",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -1264,13 +1480,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1345,13 +1557,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1363,13 +1571,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1409,13 +1613,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1427,13 +1627,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "WebUrl",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "WebUrl",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1500,13 +1696,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1587,13 +1779,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1869,13 +2057,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1928,13 +2112,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2038,6 +2218,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -2068,19 +2254,15 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Address",
-                      "ofType": null
-                    }
+                    "kind": "OBJECT",
+                    "name": "Address",
+                    "ofType": null
                   }
                 }
               },
@@ -2088,19 +2270,15 @@
               "deprecationReason": null
             },
             {
-              "name": "categoryId",
+              "name": "category",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Category",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2162,19 +2340,15 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Date",
-                      "ofType": null
-                    }
+                    "kind": "OBJECT",
+                    "name": "Date",
+                    "ofType": null
                   }
                 }
               },
@@ -2196,19 +2370,43 @@
               "deprecationReason": null
             },
             {
+              "name": "externalId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listDate",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2300,6 +2498,20 @@
               "deprecationReason": null
             },
             {
+              "name": "region",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Region",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "regionId",
               "description": null,
               "args": [
@@ -2342,6 +2554,20 @@
               "deprecationReason": null
             },
             {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tagList",
               "description": null,
               "args": [
@@ -2370,13 +2596,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2465,13 +2687,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2594,19 +2812,56 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "startDate",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Region",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
               "description": null,
               "args": [
 
@@ -2679,6 +2934,18 @@
             },
             {
               "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listDate_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listDate_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -2784,19 +3051,29 @@
               "deprecationReason": null
             },
             {
+              "name": "externalId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "fullVersion",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2808,13 +3085,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2854,13 +3127,23 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2872,13 +3155,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2892,6 +3171,20 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "WebUrl",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -2959,13 +3252,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3075,6 +3364,18 @@
               "deprecationReason": null
             },
             {
+              "name": "publishedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishedAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
@@ -3131,19 +3432,15 @@
               "deprecationReason": null
             },
             {
-              "name": "categoryId",
+              "name": "category",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Category",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3259,13 +3556,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3341,13 +3634,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3384,6 +3673,20 @@
                     "ofType": null
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settings",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Setting",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3433,37 +3736,6 @@
                     "name": "WebUrl",
                     "ofType": null
                   }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Region",
-          "description": null,
-          "fields": [
-            {
-              "name": "name",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -3532,8 +3804,104 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PublicHtmlFile",
+          "description": null,
+          "fields": [
+            {
+              "name": "content",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PublicJsonFile",
+          "description": null,
+          "fields": [
+            {
+              "name": "content",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -3542,9 +3910,66 @@
           "description": null,
           "fields": [
             {
+              "name": "createAppUserContent",
+              "description": null,
+              "args": [
+                {
+                  "name": "dataSource",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "dataType",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "content",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AppUserContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createEventRecord",
               "description": null,
               "args": [
+                {
+                  "name": "forceCreate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "parentId",
                   "description": null,
@@ -3557,6 +3982,16 @@
                 },
                 {
                   "name": "description",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "externalId",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -3614,21 +4049,31 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "categoryId",
+                  "name": "categoryName",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
                 },
                 {
-                  "name": "regionId",
+                  "name": "regionName",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "region",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "RegionInput",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -3657,16 +4102,6 @@
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "LocationInput",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "dataProvider",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "DataProviderInput",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -3799,7 +4234,37 @@
               "description": null,
               "args": [
                 {
+                  "name": "forceCreate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "author",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "title",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "externalId",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
@@ -3859,6 +4324,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "showPublishDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "sourceUrl",
                   "description": null,
                   "type": {
@@ -3874,16 +4349,6 @@
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "AddressInput",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "dataProvider",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "DataProviderInput",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -3923,6 +4388,16 @@
               "name": "createPointOfInterest",
               "description": null,
               "args": [
+                {
+                  "name": "forceCreate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "name",
                   "description": null,
@@ -3968,11 +4443,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "categoryId",
+                  "name": "categoryName",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4006,7 +4481,7 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "prices",
+                  "name": "priceInformations",
                   "description": null,
                   "type": {
                     "kind": "LIST",
@@ -4038,16 +4513,6 @@
                         "ofType": null
                       }
                     }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "dataProvider",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "DataProviderInput",
-                    "ofType": null
                   },
                   "defaultValue": null
                 },
@@ -4139,9 +4604,17 @@
                   "name": "tags",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null
                 }
@@ -4162,6 +4635,16 @@
               "name": "createTour",
               "description": null,
               "args": [
+                {
+                  "name": "forceCreate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "name",
                   "description": null,
@@ -4207,11 +4690,11 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "categoryId",
+                  "name": "categoryName",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4240,16 +4723,6 @@
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "ContactInput",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "dataProvider",
-                  "description": null,
-                  "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "DataProviderInput",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -4301,6 +4774,44 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "location",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LocationInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "certificates",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "CertificateInput",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "accessibilityInformation",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AccessibilityInformationInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "lengthKm",
                   "description": null,
                   "type": {
@@ -4346,9 +4857,17 @@
                   "name": "tags",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null
                 }
@@ -4359,6 +4878,57 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "Tour",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "destroyRecord",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "recordType",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "externalId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Destroy",
                   "ofType": null
                 }
               },
@@ -4410,6 +4980,16 @@
           "description": null,
           "fields": null,
           "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
             {
               "name": "addition",
               "description": null,
@@ -4485,13 +5065,9 @@
               "name": "latitude",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "AnyPrimitive",
+                "ofType": null
               },
               "defaultValue": null
             },
@@ -4499,73 +5075,8 @@
               "name": "longitude",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "DataProviderInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "name",
-              "description": null,
-              "type": {
                 "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "address",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "AddressInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "contact",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ContactInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "logo",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "WebUrlInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "name": "AnyPrimitive",
                 "ofType": null
               },
               "defaultValue": null
@@ -4576,80 +5087,11 @@
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "ContactInput",
+          "kind": "SCALAR",
+          "name": "AnyPrimitive",
           "description": null,
           "fields": null,
-          "inputFields": [
-            {
-              "name": "firstName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lastName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "phone",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "fax",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "webUrls",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "WebUrlInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "email",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
+          "inputFields": null,
           "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
@@ -4744,7 +5186,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "AnyPrimitive",
                 "ofType": null
               },
               "defaultValue": null
@@ -4754,7 +5196,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "AnyPrimitive",
                 "ofType": null
               },
               "defaultValue": null
@@ -4786,6 +5228,85 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "ContactInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "firstName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "phone",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fax",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "webUrls",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WebUrlInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "email",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "OperatingCompanyInput",
           "description": null,
           "fields": null,
@@ -4794,13 +5315,9 @@
               "name": "name",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null
             },
@@ -4821,6 +5338,147 @@
                 "kind": "INPUT_OBJECT",
                 "name": "ContactInput",
                 "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LocationInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "department",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "district",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "regionName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "geoLocation",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "GeoLocationInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CertificateInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AccessibilityInformationInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "types",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "urls",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WebUrlInput",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null
             }
@@ -4953,7 +5611,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "LocationInput",
+          "name": "RegionInput",
           "description": null,
           "fields": null,
           "inputFields": [
@@ -4963,56 +5621,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "department",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "district",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "regionId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "state",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "geoLocation",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "GeoLocationInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -5043,7 +5651,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "AnyPrimitive",
                 "ofType": null
               },
               "defaultValue": null
@@ -5145,55 +5753,6 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "AccessibilityInformationInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "description",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "types",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "urls",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "WebUrlInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
           "name": "OpeningHourInput",
           "description": null,
           "fields": null,
@@ -5284,27 +5843,154 @@
           "possibleTypes": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "CertificateInput",
+          "kind": "OBJECT",
+          "name": "AppUserContent",
           "description": null,
-          "fields": null,
-          "inputFields": [
+          "fields": [
             {
-              "name": "name",
+              "name": "content",
               "description": null,
+              "args": [
+
+              ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
-              "defaultValue": null
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dataSource",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dataType",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
-          "interfaces": null,
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Destroy",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "statusCode",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/spec/factories/app_user_contents.rb
+++ b/spec/factories/app_user_contents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :app_user_content do
     id { 1 }

--- a/spec/factories/app_user_contents.rb
+++ b/spec/factories/app_user_contents.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :app_user_content do
+    id { 1 }
+    content { "MyText" }
+    data_type { "MyString" }
+    data_source { "MyString" }
+  end
+end
+
+# == Schema Information
+#
+# Table name: app_user_contents
+#
+#  id          :bigint           not null, primary key
+#  content     :text(65535)
+#  data_type   :string(255)
+#  data_source :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/spec/models/app_user_content_spec.rb
+++ b/spec/models/app_user_content_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe AppUserContent, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end
+
+# == Schema Information
+#
+# Table name: app_user_contents
+#
+#  id          :bigint           not null, primary key
+#  content     :text(65535)
+#  data_type   :string(255)
+#  data_source :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/spec/models/app_user_content_spec.rb
+++ b/spec/models/app_user_content_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe AppUserContent, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { is_expected.to validate_presence_of(:content) }
+  it { is_expected.to validate_presence_of(:data_type) }
+  it { is_expected.to validate_presence_of(:data_source) }
 end
 
 # == Schema Information

--- a/spec/models/app_user_content_spec.rb
+++ b/spec/models/app_user_content_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe AppUserContent, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
At first I adjusted existing views to have them in an identical style and rendering with a same structure across all models. This was the base for the new views, which needs to be created.

The main server should be able to receive form inputs. Therefore a new model `AppUserContent` is introduced. It has similar fields as `StaticContent`. An objects data is stored in `content`. Its format is described by a `date_type`. This will be `json` for our first use case, as we will send form data as json strings. A `data_source` should be set, to be able to filter or group data later, when there will be more. For the first use case, this will be `form`.

The views are adapted from the existing ones and based on StaticContent views.

The graphql stuff is also adapted from existing code and changed to the arguments of the new model.

**TODOs**:

- [ ] send e-mail after creation
- [x] specs
- [ ] spam filter

Have fun 👀 
Now the mobile app part needs to be developed.