### PR TITLE
feat(static contents): add scope for data type

### DIFF
--- a/app/controllers/static_contents_controller.rb
+++ b/app/controllers/static_contents_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StaticContentsController < ApplicationController
   layout "doorkeeper/admin"
 
@@ -14,6 +16,7 @@ class StaticContentsController < ApplicationController
   # GET /static_contents.json
   def index
     @static_contents = StaticContent.all
+    @static_contents = @static_contents.filter_by_type(params[:type]) if params[:type].present?
   end
 
   # GET /static_contents/1
@@ -37,7 +40,7 @@ class StaticContentsController < ApplicationController
 
     respond_to do |format|
       if @static_content.save
-        format.html { redirect_to @static_content, notice: 'Static content was successfully created.' }
+        format.html { redirect_to @static_content, notice: "Static content was successfully created." }
         format.json { render :show, status: :created, location: @static_content }
       else
         format.html { render :new }
@@ -51,7 +54,7 @@ class StaticContentsController < ApplicationController
   def update
     respond_to do |format|
       if @static_content.update(static_content_params)
-        format.html { redirect_to @static_content, notice: 'Static content was successfully updated.' }
+        format.html { redirect_to @static_content, notice: "Static content was successfully updated." }
         format.json { render :show, status: :ok, location: @static_content }
       else
         format.html { render :edit }
@@ -65,12 +68,13 @@ class StaticContentsController < ApplicationController
   def destroy
     @static_content.destroy
     respond_to do |format|
-      format.html { redirect_to static_contents_url, notice: 'Static content was successfully destroyed.' }
+      format.html { redirect_to static_contents_url, notice: "Static content was successfully destroyed." }
       format.json { head :no_content }
     end
   end
 
   private
+
     # Use callbacks to share common setup or constraints between actions.
     def set_static_content
       @static_content = StaticContent.find(params[:id])

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 class StaticContent < ApplicationRecord
+  scope :filter_by_type, ->(type) { where data_type: type }
 end
 
 # == Schema Information

--- a/app/views/static_contents/index.html.erb
+++ b/app/views/static_contents/index.html.erb
@@ -1,8 +1,21 @@
+<%
+  def btn_class(type = nil)
+    return "btn-secondary" if params[:type].blank? && type.blank?
+    return params[:type] == type ? "btn-secondary" : "btn-outline-secondary"
+  end
+%>
+
 <div class="row">
   <div class="col">
     <h1>Static Contents</h1>
 
     <p><%= link_to 'New Static Content', new_static_content_path, class: "btn btn-success" %></p>
+
+    <div class="btn-group btn-group-sm mb-3" role="group" aria-label="Choose data type">
+      <a href="<%= static_contents_path %>" class="btn <%= btn_class("") %>">All</a>
+      <a href="<%= static_contents_path(type: "json") %>" class="btn <%= btn_class("json") %>">JSON</a>
+      <a href="<%= static_contents_path(type: "html") %>" class="btn <%= btn_class("html") %>">HTML</a>
+    </div>
 
     <table class="table table-striped">
       <thead>


### PR DESCRIPTION
- added scope on `data_type` for `StaticContent` to
  be able to filter for specific records
- added usage of scope in `#index` for `StaticContentsController`
  if a url param is present
- added buttons in the index template to trigger certain filter
  - included a helper method to determine the css class for
    buttons depending on url params and a given type

![Bildschirmfoto 2020-07-09 um 18 09 00-side](https://user-images.githubusercontent.com/1942953/87064424-01948f80-c210-11ea-804d-a19ace67f88f.png)
