### PR TITLE
fix(content editor): fix creation of JSON static contents

### DIFF
--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class StaticContent < ApplicationRecord
+  validates_presence_of :name, :data_type
+  validates :name, uniqueness: { case_sensitive: false }
+
   scope :filter_by_type, ->(type) { where data_type: type }
 end
 

--- a/app/views/app_user_contents/_form.html.erb
+++ b/app/views/app_user_contents/_form.html.erb
@@ -40,21 +40,19 @@
   $(function () {
     var container = document.getElementById("code_editor")
     var options = {
-      mode: 'code',
-      <% if app_user_content.data_type == "json" %>
-        modes: ['code', 'tree'],
-      <% end %>
+      statusBar: false,
+      modes: ['code', 'tree'],
       onChangeText: function(jsonString) {
-        $("#app_user_content_content").val(jsonString)
+        $("#app_user_content_content").val(jsonString);
       }
     }
     var editor = new JSONEditor(container, options)
 
     <% content = app_user_content.content.to_s.html_safe %>
-    <% if app_user_content.data_type == "html" %>
-      editor.setText("<%= escape_javascript(content) %>")
+    <% if content.present? %>
+      editor.set(<%= content %>);
     <% else %>
-      editor.set(<%= content %>)
+      editor.set({});
     <% end %>
   });
 </script>

--- a/app/views/app_user_contents/show.html.erb
+++ b/app/views/app_user_contents/show.html.erb
@@ -27,7 +27,8 @@
   $(function () {
     var container = document.getElementById("code_editor")
     var options = {
-      mode: 'code',
+      statusBar: false,
+      modes: ['code', 'view'],
       onEditable: function (node) {
         if (!node.path) {
           // In modes code and text, node is empty: no path, field, or value
@@ -39,10 +40,10 @@
     var editor = new JSONEditor(container, options)
 
     <% content = @app_user_content.content.to_s.html_safe %>
-    <% if @app_user_content.data_type == "html" %>
-      editor.setText("<%= escape_javascript(content) %>")
+    <% if content.present? %>
+      editor.set(<%= content %>);
     <% else %>
-      editor.set(<%= content %>)
+      editor.set({});
     <% end %>
   });
 </script>

--- a/app/views/static_contents/_form.html.erb
+++ b/app/views/static_contents/_form.html.erb
@@ -40,21 +40,32 @@
   $(function () {
     var container = document.getElementById("code_editor")
     var options = {
+      statusBar: false,
+      mainMenuBar: false,
       mode: 'code',
       <% if static_content.data_type == "json" %>
+        mainMenuBar: true,
         modes: ['code', 'tree'],
       <% end %>
       onChangeText: function(jsonString) {
-        $("#static_content_content").val(jsonString)
+        $("#static_content_content").val(jsonString);
       }
     }
     var editor = new JSONEditor(container, options)
 
     <% content = static_content.content.to_s.html_safe %>
-    <% if static_content.data_type == "html" %>
-      editor.setText("<%= escape_javascript(content) %>")
+    <% if static_content.data_type == "json" %>
+      <% if content.present? %>
+        editor.set(<%= content %>);
+      <% else %>
+        editor.set({});
+      <% end %>
     <% else %>
-      editor.set(<%= content %>)
+      <% if content.present? %>
+        editor.setText("<%= escape_javascript(content) %>");
+      <% else %>
+        editor.setText("");
+      <% end %>
     <% end %>
   });
 </script>

--- a/app/views/static_contents/show.html.erb
+++ b/app/views/static_contents/show.html.erb
@@ -23,7 +23,13 @@
   $(function () {
     var container = document.getElementById("code_editor")
     var options = {
+      statusBar: false,
+      mainMenuBar: false,
       mode: 'code',
+      <% if @static_content.data_type == "json" %>
+        mainMenuBar: true,
+        modes: ['code', 'view'],
+      <% end %>
       onEditable: function (node) {
         if (!node.path) {
           // In modes code and text, node is empty: no path, field, or value
@@ -35,10 +41,18 @@
     var editor = new JSONEditor(container, options)
 
     <% content = @static_content.content.to_s.html_safe %>
-    <% if @static_content.data_type == "html" %>
-      editor.setText("<%= escape_javascript(content) %>")
+    <% if @static_content.data_type == "json" %>
+      <% if content.present? %>
+        editor.set(<%= content %>);
+      <% else %>
+        editor.set({});
+      <% end %>
     <% else %>
-      editor.set(<%= content %>)
+      <% if content.present? %>
+        editor.setText("<%= escape_javascript(content) %>");
+      <% else %>
+        editor.setText("");
+      <% end %>
     <% end %>
   });
 </script>

--- a/spec/models/static_content_spec.rb
+++ b/spec/models/static_content_spec.rb
@@ -1,7 +1,11 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe StaticContent, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:data_type) }
+  it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
 end
 
 # == Schema Information


### PR DESCRIPTION
- updated setup for JSONEditor
- set correct typed fallbacks for empty contents
- updated the editor for app user contents as well
- added model validations for `StaticContent`
  - a `name` must be unique without regarding the case

Fixes #142