### PR TITLE
refactor: scope event records to upcoming ones

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -5,7 +5,7 @@ require "graphql/query_resolver"
 class Resolvers::EventRecordsSearch
   include SearchObject.module(:graphql)
 
-  scope { EventRecord.filtered_for_current_user(context[:current_user]) }
+  scope { EventRecord.upcoming(context[:current_user]) }
 
   type types[Types::EventRecordType]
 

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -31,6 +31,20 @@ class EventRecord < ApplicationRecord
     where(data_provider_id: current_user.data_provider_id)
   }
 
+  scope :upcoming, lambda { |current_user|
+    event_records = if current_user.present?
+                      EventRecord.filtered_for_current_user(current_user)
+                    else
+                      EventRecord.all
+                    end
+
+    upcoming_event_record_ids = event_records.select do |event_record|
+      event_record.list_date >= Date.today
+    end.map(&:id)
+
+    where(id: upcoming_event_record_ids)
+  }
+
   accepts_nested_attributes_for :urls, reject_if: ->(attr) { attr[:url].blank? }
   accepts_nested_attributes_for :data_provider, :organizer,
                                 :addresses, :location, :contacts,


### PR DESCRIPTION
- added a new scope to filter event records
  - return only upcoming events
  - a current user can be applied to pre filter records
     with using the existing  scope `filtered_for_current_user`
- updated the graphql resolver for event records to
  use the new scope, whichs implies the previous one

Resolves #145