### PR TITLE
refactor: add specific branch for gitlab-ci build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ build:
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
     - docker push $CI_REGISTRY_IMAGE:latest
   only:
-    - release/bad-belzig-app
+    - some-explicit-branch
 
 tag:
   stage: tag
@@ -36,7 +36,7 @@ tag:
     - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA $CI_REGISTRY_IMAGE:production
     - docker push $CI_REGISTRY_IMAGE:production
   only:
-    - release/bad-belzig-app
+    - some-explicit-branch
 
 deploy:
   stage: deploy
@@ -51,4 +51,4 @@ deploy:
   script:
     - ssh gitlab@$TARGET_HOST sudo salt-call --local --retcode-passthrough state.apply bad-belzig
   only:
-    - release/bad-belzig-app
+    - some-explicit-branch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,8 @@ build:
     - docker build --cache-from $CI_REGISTRY_IMAGE:latest --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA --tag $CI_REGISTRY_IMAGE:latest .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
     - docker push $CI_REGISTRY_IMAGE:latest
+  only:
+    - release/bad-belzig-app
 
 tag:
   stage: tag


### PR DESCRIPTION
refactor: add specific branch for gitlab-ci build

- add only option with the branch, that is set for the other
  stages

refactor(gitlab ci): update branch name in only options
    
- set to a branch, that does not exist, because master should
  not trigger anything

Resolves #147