### PR TITLE
fix: update resolver methods to succeed when combined with arrays

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -22,17 +22,21 @@ class Resolvers::EventRecordsSearch
     value "listDate_ASC"
   end
 
+  option :skip, type: types.Int, with: :apply_skip
   option :limit, type: types.Int, with: :apply_limit
   option :take, type: types.Int, with: :apply_take
-  option :skip, type: types.Int, with: :apply_skip
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
 
   def apply_limit(scope, value)
     scope.limit(value)
+  rescue NoMethodError
+    scope.first(value)
   end
 
   def apply_skip(scope, value)
     scope.offset(value)
+  rescue NoMethodError
+    scope.drop(value)
   end
 
   def apply_take(scope, value)


### PR DESCRIPTION
- sorting event records by list_date returns an array, so `offset` and
  `limit` cannot be used
  - `offset` can be achieved for arrays with `drop`
    - thx to: https://stackoverflow.com/a/29511939
  - `limit` is equivalent to `first`
- the order of options is relevant for the called chain of methods
  - knowing this, `skip` needs to be the first method that is called
    to have correct results