### PR TITLE
feat: add alive check endpoint for the mobile app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,7 @@
 class ApplicationController < ActionController::Base
   layout "doorkeeper/application"
 
+  def generate_204
+    head(:no_content)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
 
   post "/graphql", to: "graphql#execute"
 
+  get "/generate_204", to: "application#generate_204", status: 204
+
   root to: "oauth/applications#index"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
- create a simple head-only route to return a 204 status
  with no content
  - this can be used by the app to check, if the mainserver is up
    and reachable
  - currently a default `https://clients3.google.com/generate_204`
    is used, which does not help us to check for the main server
    - on the other hand, we do not want to depend on google for
      that case