### PR TITLE
feat(news filter): add option to filter news on data providers

### DIFF
--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -24,6 +24,7 @@ class Resolvers::NewsItemsSearch
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: NewsItemsOrder, default: "publishedAt_DESC"
+  option :dataProvider, type: types.String, with: :apply_data_provider
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -35,6 +36,10 @@ class Resolvers::NewsItemsSearch
 
   def apply_order(scope, value)
     scope.order(value)
+  end
+
+  def apply_data_provider(scope, value)
+    scope.joins(:data_provider).where(data_providers: { name: value })
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -376,7 +376,7 @@ type Query {
   eventRecord(id: ID!): EventRecord!
   eventRecords(limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
   newsItem(id: ID!): NewsItem!
-  newsItems(limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
+  newsItems(dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!

--- a/public/schema.json
+++ b/public/schema.json
@@ -212,6 +212,16 @@
                     "ofType": null
                   },
                   "defaultValue": "publishedAt_DESC"
+                },
+                {
+                  "name": "dataProvider",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -376,7 +376,7 @@ type Query {
   eventRecord(id: ID!): EventRecord!
   eventRecords(limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
   newsItem(id: ID!): NewsItem!
-  newsItems(limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
+  newsItems(dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!

--- a/schema.json
+++ b/schema.json
@@ -212,6 +212,16 @@
                     "ofType": null
                   },
                   "defaultValue": "publishedAt_DESC"
+                },
+                {
+                  "name": "dataProvider",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {


### PR DESCRIPTION
- added dataProvider option and method to search resolver objects to be
  able to query for news items, which belong to a certain data provider
- updated schemas per `rails graphql:schema:dump`
  - copied the two schema files from public/ to /, because they are
    also there for some very unclear but necessary(?) reason

SVA-31