### PR TITLE
feat(news filter): add query for data providers of news items

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -55,9 +55,7 @@ module Types
     end
 
     def news_items_data_providers
-      order = "data_providers.name ASC"
-
-      NewsItem.all.includes(:data_provider).order(order).map(&:data_provider).uniq
+      DataProvider.joins(:news_items).order(:name).uniq
     end
 
     # Provide contents from html files in `public/mobile-app/contents` through GraphQL query

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -32,6 +32,8 @@ module Types
 
     field :categories, [CategoryType], null: false
 
+    field :news_items_data_providers, [DataProviderType], null: false
+
     def point_of_interest(id:)
       PointOfInterest.find(id)
     end
@@ -50,6 +52,12 @@ module Types
 
     def categories
       Category.all.order(:name)
+    end
+
+    def news_items_data_providers
+      order = "data_providers.name ASC"
+
+      NewsItem.all.includes(:data_provider).order(order).map(&:data_provider).uniq
     end
 
     # Provide contents from html files in `public/mobile-app/contents` through GraphQL query

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -4,6 +4,7 @@ class DataProvider < ApplicationRecord
   store :roles, accessors: %i[role_point_of_interest role_tour role_news_item role_event_record], coder: JSON
 
   has_many :data_resource_settings, class_name: "DataResourceSetting"
+  has_many :news_items
   has_one :user
   has_one :address, as: :addressable
   has_one :contact, as: :contactable

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -377,6 +377,7 @@ type Query {
   eventRecords(limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
   newsItem(id: ID!): NewsItem!
   newsItems(dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
+  newsItemsDataProviders: [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!

--- a/public/schema.json
+++ b/public/schema.json
@@ -237,6 +237,32 @@
               "deprecationReason": null
             },
             {
+              "name": "newsItemsDataProviders",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DataProvider",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pointOfInterest",
               "description": null,
               "args": [

--- a/schema.graphql
+++ b/schema.graphql
@@ -377,6 +377,7 @@ type Query {
   eventRecords(limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
   newsItem(id: ID!): NewsItem!
   newsItems(dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
+  newsItemsDataProviders: [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!

--- a/schema.json
+++ b/schema.json
@@ -237,6 +237,32 @@
               "deprecationReason": null
             },
             {
+              "name": "newsItemsDataProviders",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DataProvider",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pointOfInterest",
               "description": null,
               "args": [


### PR DESCRIPTION
- added query for data providers, which have news items in the database, which
  can be used as a filter list in the app
  - the sql query gets only the data providers per `:includes`, which are connected
    in the news items table per `data_provider_id` (news_item belongs_to data_provider)
- updated schemas per `rails graphql:schema:dump`
  - copied the two schema files from public/ to /, because they are
    also there for some very unclear but necessary(?) reason

SVA-31