### PR TITLE
Batch action update default categories

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -60,6 +60,17 @@ class AccountsController < ApplicationController
     end
   end
 
+  # get /accounts/3/batch_defaults?data_resource_type=NewsItem
+  def batch_defaults
+    @user = User.find(params["id"])
+    data_resource_type = params[:data_resource_type]
+    system "rake batch_defaults:create DATAPROVIDER_ID=#{@user.data_provider_id} DATA_RESOURCE_TYPE=#{data_resource_type}"
+    flash[:notice] = "Batch Action wurde gestartet für den Typ #{data_resource_type}"
+    respond_to do |format|
+      format.html { redirect_to action: :edit }
+    end
+  end
+
   def account_params
     values = params.require(:user).permit(
       :email,

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -5,6 +5,9 @@ class DataProvider < ApplicationRecord
 
   has_many :data_resource_settings, class_name: "DataResourceSetting"
   has_many :news_items
+  has_many :tours
+  has_many :point_of_interests
+  has_many :event_records
   has_one :user
   has_one :address, as: :addressable
   has_one :contact, as: :contactable

--- a/app/models/data_resources/point_of_interest.rb
+++ b/app/models/data_resources/point_of_interest.rb
@@ -7,6 +7,8 @@
 class PointOfInterest < Attraction
   attr_accessor :force_create
 
+  belongs_to :data_provider
+
   has_many :data_resource_categories, -> { where(data_resource_type: "PointOfInterest") }, foreign_key: :data_resource_id
   has_many :categories, through: :data_resource_categories
   has_many :opening_hours, as: :openingable, dependent: :destroy

--- a/app/models/data_resources/tour.rb
+++ b/app/models/data_resources/tour.rb
@@ -8,6 +8,8 @@ class Tour < Attraction
   attr_accessor :force_create
   enum means_of_transportation: { bike: 0, canoe: 1, foot: 2 }
 
+  belongs_to :data_provider
+
   has_many :data_resource_categories, -> { where(data_resource_type: "Tour") }, foreign_key: :data_resource_id
   has_many :categories, through: :data_resource_categories
   has_many :geometry_tour_data, as: :geo_locateable, class_name: "GeoLocation", dependent: :destroy

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -236,10 +236,14 @@
         <small class="form-text text-muted">
           Ausgewählte Kategorien werden beim Import diesen Elementen zusätzlich automatisch zugewiesen.
         </small>
-
         <small class="form-text text-muted">
-          Bei allen Einträgen dieses Dataproviders vom Typ <%= s.object.data_resource_type %> können die hier definierten Kategorien nachträglich gesetzt werden:
-          <%= link_to t('doorkeeper.applications.buttons.batch_action'), batch_defaults_account_path(@user, data_resource_type: s.object.data_resource_type), "data-confirm": "Wollen sie bei allen Einträgen dieses Dataproviders vom Typ #{s.object.data_resource_type} diese ausgewählten Kategorien hinzufügen? ACHTUNG: Veränderungen müssen zuvor gespeichert werden!" %>
+          Bei allen Einträgen dieses Data Providers vom Typ <%= s.object.data_resource_type %>
+          können die hier definierten Kategorien nachträglich gesetzt werden:
+          <%= link_to(
+                t("doorkeeper.applications.buttons.batch_action"),
+                batch_defaults_account_path(@user, data_resource_type: s.object.data_resource_type),
+                "data-confirm": "Sollen bei allen Einträgen dieses Data Providers vom Typ #{s.object.data_resource_type} die ausgewählten Kategorien hinzugefügt werden? ACHTUNG: Veränderungen müssen zuvor gespeichert werden!"
+              ) %>
         </small>
       </div>
     </div>

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -236,6 +236,11 @@
         <small class="form-text text-muted">
           Ausgewählte Kategorien werden beim Import diesen Elementen zusätzlich automatisch zugewiesen.
         </small>
+
+        <small class="form-text text-muted">
+          Bei allen Einträgen dieses Dataproviders vom Typ <%= s.object.data_resource_type %> können die hier definierten Kategorien nachträglich gesetzt werden:
+          <%= link_to t('doorkeeper.applications.buttons.batch_action'), batch_defaults_account_path(@user, data_resource_type: s.object.data_resource_type), "data-confirm": "Wollen sie bei allen Einträgen dieses Dataproviders vom Typ #{s.object.data_resource_type} diese ausgewählten Kategorien hinzufügen? ACHTUNG: Veränderungen müssen zuvor gespeichert werden!" %>
+        </small>
       </div>
     </div>
   <% end %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -9,7 +9,7 @@
         <tr>
           <th>ID</th>
           <th>E-Mail</th>
-          <th>Dataprovider</th>
+          <th>Data Provider</th>
           <th>Rolle</th>
           <th>CMS POI <span class="badge badge-secondary">Kategorie gesetzt?</span></th>
           <th>CMS Tour <span class="badge badge-secondary">Kategorie gesetzt?</span></th>

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -28,6 +28,7 @@ en:
         cancel: 'Cancel'
         back: 'Back'
         authorize: 'Authorize'
+        batch_action: "Batch Action starten"
       form:
         error: 'Whoops! Check your form for possible errors'
       help:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
   get "data_provider", to: "data_provider#show", as: :data_provider
   get "data_provider/edit", as: :edit_data_provider
   post "data_provider/update", as: :update_data_provider
-  resources :accounts
+  resources :accounts do
+    member do
+      get "batch_defaults"
+    end
+  end
 
   use_doorkeeper do
     controllers applications: "oauth/applications"

--- a/lib/tasks/batch_defaults.rake
+++ b/lib/tasks/batch_defaults.rake
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 namespace :batch_defaults do
-  desc "Sets default categoreis to all elements of a given dataprovider and data_resource_type"
+  desc "Sets default categories to all elements of a given data_provider and data_resource_type"
   task create: :environment do
     data_resource_type = ENV["DATA_RESOURCE_TYPE"]
     raise "data_resource_type does not exist" unless DataResourceSetting::DATA_RESOURCES.map(&:to_s).include?(data_resource_type)
 
-    dataprovider_id = ENV["DATAPROVIDER_ID"]
-    data_provider = DataProvider.find_by(id: dataprovider_id)
+    data_provider_id = ENV["DATAPROVIDER_ID"]
+    data_provider = DataProvider.find_by(id: data_provider_id)
     raise "data_provider does not exist" if data_provider.blank?
 
-    puts "Running batch action with dataprovider_id #{dataprovider_id} and data_resource_type #{data_resource_type}"
+    puts "Running batch action with data_provider_id #{data_provider_id} and data_resource_type #{data_resource_type}"
 
     default_category_ids = data_provider.settings(data_resource_type).try(:default_category_ids)
     raise "No default categories defined" if default_category_ids.blank?

--- a/lib/tasks/batch_defaults.rake
+++ b/lib/tasks/batch_defaults.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :batch_defaults do
+  desc "Sets default categoreis to all elements of a given dataprovider and data_resource_type"
+  task create: :environment do
+    data_resource_type = ENV["DATA_RESOURCE_TYPE"]
+    raise "data_resource_type does not exist" unless DataResourceSetting::DATA_RESOURCES.map(&:to_s).include?(data_resource_type)
+
+    dataprovider_id = ENV["DATAPROVIDER_ID"]
+    data_provider = DataProvider.find_by(id: dataprovider_id)
+    raise "data_provider does not exist" if data_provider.blank?
+
+    puts "Running batch action with dataprovider_id #{dataprovider_id} and data_resource_type #{data_resource_type}"
+
+    default_category_ids = data_provider.settings(data_resource_type).try(:default_category_ids)
+    raise "No default categories defined" if default_category_ids.blank?
+
+    data_elements = data_provider.send(data_resource_type.underscore.pluralize)
+    data_elements.each do |data_element|
+      data_element.categories << Category.where(id: default_category_ids)
+    end
+
+    puts "#{data_elements.count} elements updated"
+  end
+end


### PR DESCRIPTION
- UI erweitert um eine BatchAction für einen DatenTyp zu starten
- RakeTask angelegt, der die eigentliche Action ausführt
- Datenmodel von DataProvider erweitert, sodass seine data_resources direkt angesprochen werden können

![Bildschirmfoto 2020-11-05 um 13 38 51](https://user-images.githubusercontent.com/90779/98251963-b437ed00-1f79-11eb-81dd-f0884308020d.png)
