### PR TITLE
feat(categories): match type of category id

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -27,7 +27,7 @@ class Resolvers::EventRecordsSearch
   option :limit, type: types.Int, with: :apply_limit
   option :take, type: types.Int, with: :apply_take
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
-  option :categoryId, type: types.String, with: :apply_category_id
+  option :categoryId, type: types.ID, with: :apply_category_id
 
   def apply_limit(scope, value)
     scope.limit(value)

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -25,7 +25,7 @@ class Resolvers::NewsItemsSearch
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: NewsItemsOrder, default: "publishedAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
-  option :categoryId, type: types.String, with: :apply_category_id
+  option :categoryId, type: types.ID, with: :apply_category_id
 
   def apply_limit(scope, value)
     scope.limit(value)

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -383,9 +383,9 @@ type PublicJsonFile {
 type Query {
   categories: [Category!]!
   eventRecord(id: ID!): EventRecord!
-  eventRecords(categoryId: String, limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
+  eventRecords(categoryId: ID, limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
   newsItem(id: ID!): NewsItem!
-  newsItems(categoryId: String, dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
+  newsItems(categoryId: ID, dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
   newsItemsDataProviders(categoryId: ID): [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]

--- a/public/schema.json
+++ b/public/schema.json
@@ -140,7 +140,7 @@
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -238,7 +238,7 @@
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null

--- a/schema.graphql
+++ b/schema.graphql
@@ -383,9 +383,9 @@ type PublicJsonFile {
 type Query {
   categories: [Category!]!
   eventRecord(id: ID!): EventRecord!
-  eventRecords(categoryId: String, limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
+  eventRecords(categoryId: ID, limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
   newsItem(id: ID!): NewsItem!
-  newsItems(categoryId: String, dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
+  newsItems(categoryId: ID, dataProvider: String, limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
   newsItemsDataProviders(categoryId: ID): [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]

--- a/schema.json
+++ b/schema.json
@@ -140,7 +140,7 @@
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -238,7 +238,7 @@
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null


### PR DESCRIPTION
- match the category id type to have the same across all queries
- updated schemas per `rails graphql:schema:dump`
  - copied the two schema files from public/ to /, because they are
    also there for some very unclear but necessary(?) reason

SVA-32