### PR TITLE
fix(event filter): add fallback for category filter if scope is an array

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -47,6 +47,8 @@ class Resolvers::EventRecordsSearch
 
   def apply_category_id(scope, value)
     scope.with_category(value)
+  rescue NoMethodError
+    scope.select { |event_record| event_record.category_ids.include?(value.to_i) }
   end
 
   def apply_order_with_created_at_desc(scope)


### PR DESCRIPTION
- we do not know if we can call `with_category` on the scope, because the
  scope can be an array through other actions
- therefore we need to add a fallback action to filter the array,
  like for `skip` and `limit`

SVA-58