### PR TITLE
feat(event filter): change order of calling options

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -23,16 +23,16 @@ class Resolvers::EventRecordsSearch
     value "listDate_ASC"
   end
 
+  option :categoryId, type: types.ID, with: :apply_category_id
   option :skip, type: types.Int, with: :apply_skip
   option :limit, type: types.Int, with: :apply_limit
   option :take, type: types.Int, with: :apply_take
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
-  option :categoryId, type: types.ID, with: :apply_category_id
 
-  def apply_limit(scope, value)
-    scope.limit(value)
+  def apply_category_id(scope, value)
+    scope.with_category(value)
   rescue NoMethodError
-    scope.first(value)
+    scope.select { |event_record| event_record.category_ids.include?(value.to_i) }
   end
 
   def apply_skip(scope, value)
@@ -41,14 +41,14 @@ class Resolvers::EventRecordsSearch
     scope.drop(value)
   end
 
-  def apply_take(scope, value)
-    scope.take(value)
+  def apply_limit(scope, value)
+    scope.limit(value)
+  rescue NoMethodError
+    scope.first(value)
   end
 
-  def apply_category_id(scope, value)
-    scope.with_category(value)
-  rescue NoMethodError
-    scope.select { |event_record| event_record.category_ids.include?(value.to_i) }
+  def apply_take(scope, value)
+    scope.take(value)
   end
 
   def apply_order_with_created_at_desc(scope)


### PR DESCRIPTION
- somehow it helps to put `:categoryId` in first place, as it will
  be called prior to the others
- BUT `:order` will be called even before `:categoryId`, no matter that
  it is listed in last position of these options
  - why?

SVA-58