### PR TITLE
Add multiple categories per graphql

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -85,6 +85,7 @@ class AccountsController < ApplicationController
         :role_tour,
         :role_news_item,
         :role_event_record,
+        :role_push_notification,
         logo_attributes: %i[
           id
           url

--- a/app/graphql/mutations/create_news_item.rb
+++ b/app/graphql/mutations/create_news_item.rb
@@ -14,7 +14,11 @@ module Mutations
     argument :published_at, String, required: false
     argument :show_publish_date, Boolean, required: false
     argument :category_name, String, required: false
-    argument :categories, [Types::CategoryInput], required: false, as: :category_names, prepare: lambda { |category, _ctx| category.map(&:to_h) }
+    argument :categories, [Types::CategoryInput], required: false,
+                                                  as: :category_names,
+                                                  prepare: lambda { |category, _ctx|
+                                                             category.map(&:to_h)
+                                                           }
     argument :source_url, Types::WebUrlInput, required: false,
                                               as: :source_url_attributes,
                                               prepare: ->(source_url, _ctx) { source_url.to_h }

--- a/app/graphql/mutations/create_news_item.rb
+++ b/app/graphql/mutations/create_news_item.rb
@@ -14,6 +14,7 @@ module Mutations
     argument :published_at, String, required: false
     argument :show_publish_date, Boolean, required: false
     argument :category_name, String, required: false
+    argument :categories, [Types::CategoryInput], required: false, as: :category_names, prepare: lambda { |category, _ctx| category.map(&:to_h) }
     argument :source_url, Types::WebUrlInput, required: false,
                                               as: :source_url_attributes,
                                               prepare: ->(source_url, _ctx) { source_url.to_h }

--- a/app/graphql/types/category_input.rb
+++ b/app/graphql/types/category_input.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Types
+  class CategoryInput < BaseInputObject
+    argument :name, String, required: false
+  end
+end

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DataProvider < ApplicationRecord
-  store :roles, accessors: %i[role_point_of_interest role_tour role_news_item role_event_record], coder: JSON
+  store :roles, accessors: %i[role_point_of_interest role_tour role_news_item role_event_record role_push_notification], coder: JSON
 
   has_many :data_resource_settings, class_name: "DataResourceSetting"
   has_many :news_items

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -40,7 +40,7 @@ class EventRecord < ApplicationRecord
                     end
 
     upcoming_event_record_ids = event_records.select do |event_record|
-      event_record.list_date >= Date.today
+      event_record.list_date.try(:to_time).to_i >= Date.today.to_time.to_i
     end.map(&:id)
 
     where(id: upcoming_event_record_ids)
@@ -94,7 +94,7 @@ class EventRecord < ApplicationRecord
     return if dates_count.zero?
 
     future_dates = event_dates.select do |date|
-      date.date_start >= Time.zone.now.beginning_of_day
+      date.date_start.try(:to_time).to_i >= Time.zone.now.beginning_of_day.to_i
     end
     future_date = future_dates.first.try(:date_start)
 

--- a/app/models/data_resources/news_item.rb
+++ b/app/models/data_resources/news_item.rb
@@ -46,11 +46,15 @@ class NewsItem < ApplicationRecord
   end
 
   def find_or_create_category
+    # für Abwärtskompatibilität, wenn nur ein einiger Kategorienamen angegeben wird
+    # ist der attr_accessor :category_name befüllt
     if category_name.present?
       category_to_add = Category.where(name: category_name).first_or_create
       categories << category_to_add unless categories.include?(category_to_add)
     end
 
+    # Wenn mehrere Kategorein auf einmal gesetzt werden
+    # ist der attr_accessor :category_names befüllt
     if category_names.present?
       category_names.each do |cat|
         category_to_add = Category.where(name: cat[:name]).first_or_create

--- a/app/models/data_resources/news_item.rb
+++ b/app/models/data_resources/news_item.rb
@@ -5,6 +5,7 @@
 class NewsItem < ApplicationRecord
   attr_accessor :force_create
   attr_accessor :category_name
+  attr_accessor :category_names
   attr_accessor :push_notification
 
   before_validation :find_or_create_category
@@ -45,10 +46,17 @@ class NewsItem < ApplicationRecord
   end
 
   def find_or_create_category
-    return if category_name.blank?
+    if category_name.present?
+      category_to_add = Category.where(name: category_name).first_or_create
+      categories << category_to_add unless categories.include?(category_to_add)
+    end
 
-    category_to_add = Category.where(name: category_name).first_or_create
-    categories << category_to_add unless categories.include?(category_to_add)
+    if category_names.present?
+      category_names.each do |cat|
+        category_to_add = Category.where(name: cat[:name]).first_or_create
+        categories << category_to_add unless categories.include?(category_to_add)
+      end
+    end
   end
 
   # Sicherstellung der Abwärtskompatibilität seit 09/2020

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -171,15 +171,15 @@
 
   <div class="form-group">
     <div class="form-check">
-      <%= d.check_box :role_event_record, {  class: "form-check-input" }, "true", "false" %>
+      <%= d.check_box :role_event_record, { class: "form-check-input" }, "true", "false" %>
       <%= d.label :role_event_record,"Veranstaltungen", class: "form-check-label" %>
     </div>
   </div>
 
   <div class="form-group">
     <div class="form-check">
-      <%= d.check_box :role_push_notification, {  class: "form-check-input" }, "true", "false" %>
-      <%= d.label :role_push_notification,"Send Push Notification", class: "form-check-label" %>
+      <%= d.check_box :role_push_notification, { class: "form-check-input" }, "true", "false" %>
+      <%= d.label :role_push_notification, "Send Push Notification", class: "form-check-label" %>
     </div>
   </div>
 

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -176,6 +176,13 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <div class="form-check">
+      <%= d.check_box :role_push_notification, {  class: "form-check-input" }, "true", "false" %>
+      <%= d.label :role_push_notification,"Send Push Notification", class: "form-check-label" %>
+    </div>
+  </div>
+
   <%= d.fields_for :data_resource_settings do |s| %>
     <% I18n.with_locale(:de) do %>
       <h2>Optionen für <%= t(s.object.data_resource_type.pluralize) if s.object.data_resource_type %></h2>

--- a/app/views/layouts/doorkeeper/admin.html.erb
+++ b/app/views/layouts/doorkeeper/admin.html.erb
@@ -32,7 +32,8 @@
         <li class="nav-item">
           <%= link_to "Categories", categories_path, class: 'nav-link' %>
         </li>
-
+      <% end %>
+      <% if current_user && current_user.try(:data_provider).try(:role_push_notification) %>
         <li class="nav-item">
           <%= link_to "Push Notifications", notification_devices_path, class: 'nav-link' %>
         </li>


### PR DESCRIPTION
Argument 'categories' added with a new InputType CategoryInput as an array.
Each category name will be created and added to the news_item object

![Bildschirmfoto 2020-11-26 um 14 58 25](https://user-images.githubusercontent.com/90779/100359797-563a7a80-2ff8-11eb-8237-8d1bfce4e54a.png)

