### PR TITLE
Absicherung der Geräteregistrierung

### DIFF
--- a/app/controllers/notification/devices_controller.rb
+++ b/app/controllers/notification/devices_controller.rb
@@ -55,10 +55,15 @@ class Notification::DevicesController < ApplicationController
     @notification_device = Notification::Device.new(notification_device_params)
 
     respond_to do |format|
-      if @notification_device.save
-        format.html { redirect_to @notification_device, notice: "Device was successfully created." }
-        format.json { render :show, status: :created, location: @notification_device }
-      else
+      begin
+        if @notification_device.save
+          format.html { redirect_to @notification_device, notice: "Device was successfully created." }
+          format.json { render :show, status: :created, location: @notification_device }
+        else
+          format.html { render :new }
+          format.json { render json: @notification_device.errors, status: :unprocessable_entity }
+        end
+      rescue ActiveRecord::RecordNotUnique
         format.html { render :new }
         format.json { render json: @notification_device.errors, status: :unprocessable_entity }
       end

--- a/app/models/notification/device.rb
+++ b/app/models/notification/device.rb
@@ -3,6 +3,7 @@
 class Notification::Device < ApplicationRecord
   enum device_type: { undefined: 0, ios: 1, android: 2 }
 
+  # Zusätzlich zu der Validierung hier existiert auch ein unique Index auf das Feld 'token'
   validates_uniqueness_of :token, on: :create, message: "must be unique"
   validates_presence_of :token, on: :create, message: "can't be blank"
 end

--- a/db/migrate/20201127072145_add_index_to_notification_devices.rb
+++ b/db/migrate/20201127072145_add_index_to_notification_devices.rb
@@ -1,0 +1,5 @@
+class AddIndexToNotificationDevices < ActiveRecord::Migration[5.2]
+  def change
+    add_index "notification_devices", ["token"], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_100437) do
+ActiveRecord::Schema.define(version: 2020_11_27_072145) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -252,6 +252,7 @@ ActiveRecord::Schema.define(version: 2020_11_20_100437) do
     t.integer "device_type", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_notification_devices_on_token", unique: true
   end
 
   create_table "oauth_access_grants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
validates_uniqueness_of ist unter Umständen zu langsam:

https://stackoverflow.com/questions/23187037/rails-whats-difference-in-unique-index-and-validates-uniqueness-of

Ein unique Index auf das Feld token löst dieses Problem datenbankseitig und wirft einen Fehler zurück, falls Ein Eintrag über mehere Worker hinweg parallel versucht wird anzulegen.
Der Fehler wird nun im Controller abgefangen und ebenso als Status 422 zurückgeliefert wie es validates_uniqueness_of auch tut.