### PR TITLE
Add Mutation to change Visibility

### DIFF
--- a/app/graphql/mutations/change_visibility.rb
+++ b/app/graphql/mutations/change_visibility.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: false
+
+module Mutations
+  class ChangeVisibility < BaseMutation
+    argument :id, ID, required: true
+    argument :record_type, String, required: true
+    argument :visible, Boolean, required: true
+
+    type Types::ChangeVisibilityType
+
+    RECORD_WHITELIST = ["EventRecord", "NewsItem", "PointOfInterest", "Tour"].freeze
+
+    def resolve(id:, record_type:, visible:)
+      return error_status("recordType") unless RECORD_WHITELIST.include?(record_type)
+      return error_status("visible") unless [true, false].include?(visible)
+
+      record = record_type.constantize
+                 .filtered_for_current_user(context[:current_user])
+                 .where(id: id)
+                 .first
+      return error_status("record blank") if record.blank?
+
+      record.update(visible: visible)
+
+      OpenStruct.new(id: id, status: "visibility set to #{visible}", status_code: 200)
+    end
+
+    private
+
+      def error_status(description)
+        OpenStruct.new(id: nil, status: "Access not permitted: #{description}", status_code: 403)
+      end
+  end
+end

--- a/app/graphql/types/change_visibility_type.rb
+++ b/app/graphql/types/change_visibility_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class ChangeVisibilityType < Types::BaseObject
+    field :id, ID, null: true
+    field :status, String, null: true
+    field :status_code, Integer, null: true
+  end
+end

--- a/app/graphql/types/event_record_type.rb
+++ b/app/graphql/types/event_record_type.rb
@@ -3,6 +3,7 @@
 module Types
   class EventRecordType < Types::BaseObject
     field :id, ID, null: true
+    field :visible, Boolean, null: true
     field :settings, SettingType, null: true
     field :external_id, String, null: true
     field :parent_id, Integer, null: true

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -11,5 +11,6 @@ module Types
 
     # destroys
     field :destroy_record, mutation: Mutations::DestroyRecord
+    field :change_visibility, mutation: Mutations::ChangeVisibility
   end
 end

--- a/app/graphql/types/news_item_type.rb
+++ b/app/graphql/types/news_item_type.rb
@@ -3,6 +3,7 @@
 module Types
   class NewsItemType < Types::BaseObject
     field :id, ID, null: true
+    field :visible, Boolean, null: true
     field :settings, SettingType, null: true
     field :title, String, null: true
     field :external_id, String, null: true

--- a/app/graphql/types/point_of_interest_type.rb
+++ b/app/graphql/types/point_of_interest_type.rb
@@ -3,6 +3,7 @@
 module Types
   class PointOfInterestType < Types::BaseObject
     field :id, ID, null: true
+    field :visible, Boolean, null: true
     field :settings, SettingType, null: true
     field :name, String, null: true
     field :description, String, null: true

--- a/app/graphql/types/tour_type.rb
+++ b/app/graphql/types/tour_type.rb
@@ -3,6 +3,7 @@
 module Types
   class TourType < Types::BaseObject
     field :id, ID, null: true
+    field :visible, Boolean, null: true
     field :settings, SettingType, null: true
     field :name, String, null: true
     field :description, String, null: true

--- a/app/models/concerns/filter_by_role.rb
+++ b/app/models/concerns/filter_by_role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module FilterByRole
   extend ActiveSupport::Concern
 
@@ -7,7 +9,11 @@ module FilterByRole
     scope :filtered_for_current_user, lambda { |current_user|
       return all if current_user.admin_role?
       return visible if current_user.app_role?
-      return invisible.or(self.where(data_provider_id: current_user.data_provider_id)) if current_user.editor_role?
+
+      if current_user.editor_role?
+        data_provider_ids = [current_user.data_provider_id] + User.restricted_role.map(&:data_provider_id)
+        return where(data_provider_id: data_provider_ids.compact.flatten)
+      end
 
       where(data_provider_id: current_user.data_provider_id)
     }

--- a/app/models/concerns/filter_by_role.rb
+++ b/app/models/concerns/filter_by_role.rb
@@ -1,0 +1,19 @@
+module FilterByRole
+  extend ActiveSupport::Concern
+
+  included do
+    scope :visible, -> { where(visible: true) }
+    scope :invisible, -> { where(visible: false) }
+    scope :filtered_for_current_user, lambda { |current_user|
+      return all if current_user.admin_role?
+      return visible if current_user.app_role?
+      return invisible.or(self.where(data_provider_id: current_user.data_provider_id)) if current_user.editor_role?
+
+      where(data_provider_id: current_user.data_provider_id)
+    }
+  end
+
+  def trash
+    update_attribute :trashed, true
+  end
+end

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -2,6 +2,8 @@
 
 # this model describes the data for an event e.g. a concert or a reading.
 class EventRecord < ApplicationRecord
+  include FilterByRole
+
   attr_accessor :category_name
   attr_accessor :region_name
   attr_accessor :force_create
@@ -25,12 +27,6 @@ class EventRecord < ApplicationRecord
   has_one :repeat_duration, dependent: :destroy
   has_many :dates, as: :dateable, class_name: "FixedDate", dependent: :destroy
   has_one :external_reference, as: :external, dependent: :destroy
-
-  scope :filtered_for_current_user, lambda { |current_user|
-    return all if current_user.admin_role?
-
-    where(data_provider_id: current_user.data_provider_id)
-  }
 
   scope :upcoming, lambda { |current_user|
     event_records = if current_user.present?

--- a/app/models/data_resources/news_item.rb
+++ b/app/models/data_resources/news_item.rb
@@ -3,6 +3,8 @@
 # News Item is one of the four Main resources for the app. A news Item can be anything
 # from an old school news article to a whole story structured in chapters
 class NewsItem < ApplicationRecord
+  include FilterByRole
+
   attr_accessor :force_create
   attr_accessor :category_name
   attr_accessor :category_names
@@ -19,12 +21,6 @@ class NewsItem < ApplicationRecord
   has_one :external_reference, as: :external, dependent: :destroy
   has_one :address, as: :addressable, dependent: :destroy
   has_one :source_url, as: :web_urlable, class_name: "WebUrl", dependent: :destroy
-
-  scope :filtered_for_current_user, lambda { |current_user|
-    return all if current_user.admin_role?
-
-    where(data_provider_id: current_user.data_provider_id)
-  }
 
   scope :with_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)

--- a/app/models/data_resources/point_of_interest.rb
+++ b/app/models/data_resources/point_of_interest.rb
@@ -5,6 +5,8 @@
 # smart village and the surrounding area
 #
 class PointOfInterest < Attraction
+  include FilterByRole
+
   attr_accessor :force_create
 
   belongs_to :data_provider
@@ -14,12 +16,6 @@ class PointOfInterest < Attraction
   has_many :opening_hours, as: :openingable, dependent: :destroy
   has_many :price_informations, as: :priceable, class_name: "Price", dependent: :destroy
   has_one :location, as: :locateable, dependent: :destroy
-
-  scope :filtered_for_current_user, ->(current_user) do
-    return all if current_user.admin_role?
-
-    where(data_provider_id: current_user.data_provider_id)
-  end
 
   accepts_nested_attributes_for :price_informations, :opening_hours, :location
 

--- a/app/models/data_resources/tour.rb
+++ b/app/models/data_resources/tour.rb
@@ -5,6 +5,8 @@
 # the surrounding areas of the Smart Village
 #
 class Tour < Attraction
+  include FilterByRole
+
   attr_accessor :force_create
   enum means_of_transportation: { bike: 0, canoe: 1, foot: 2 }
 
@@ -14,12 +16,6 @@ class Tour < Attraction
   has_many :categories, through: :data_resource_categories
   has_many :geometry_tour_data, as: :geo_locateable, class_name: "GeoLocation", dependent: :destroy
   has_one :location, as: :locateable, dependent: :destroy
-
-  scope :filtered_for_current_user, ->(current_user) do
-    return all if current_user.admin_role?
-
-    where(data_provider_id: current_user.data_provider_id)
-  end
 
   accepts_nested_attributes_for :geometry_tour_data, :location
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :trackable, :omniauthable and :rememberable
   devise :database_authenticatable, :recoverable, :validatable, :lockable, :timeoutable, :token_authenticatable
-  enum role: { user: 0, admin: 1 }, _suffix: :role
+  enum role: { user: 0, admin: 1, app: 2, restricted: 3, editor: 4 }, _suffix: :role
 
   belongs_to :data_provider, optional: true
   accepts_nested_attributes_for :data_provider

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -11,6 +11,14 @@ class ResourceService
 
   def create(resource_class, params)
     @params = params
+
+    # Wenn die Rolle Restricted eine Information anlegt,
+    # so ist diese per default nicht sichtbar, es sei denn
+    # das Attribute 'visible' wird in den params mitgegeben und ist 'true'
+    if data_provider.user.restricted_role? && resource_class.respond_to?(:visible)
+      @params = { visible: false }.merge(@params)
+    end
+
     @resource_class = resource_class
     @resource = resource_class.new(params)
     @resource.data_provider = data_provider

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -23,7 +23,7 @@
 
 <div class="form-group">
   <%= f.label :role, "Rolle" %>
-  <%= f.select :role, [["Nutzer", :user], ["Admin", :admin]], {}, class: "form-control" %>
+  <%= f.select :role, User.roles.keys.map { |role| [role.humanize, role] }, {}, class: "form-control" %>
 </div>
 
 <h2>Passwort</h2>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,5 +1,51 @@
 <div class="row">
   <div class="col">
+    <h1>Rollen</h1>
+
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Rolle</th>
+          <th>Kommentar</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Admin</td>
+          <td>
+            Ein Administrator kann neue Inhalte erstellen, alle Inhalte lesen, bearbeiten und freigeben. <br />
+            Neu erstellte Inhalte sind sofort freigegeben und damit öffentlich lesbar.
+          </td>
+        </tr>
+        <tr>
+          <td>App</td>
+          <td>Ein mobile App kann alle freigegebene Inhalte lesen.</td>
+        </tr>
+        <tr>
+          <td>User</td>
+          <td>
+            Ein User kann neue Inhalte erstellen und eigene Inhalte lesen und bearbeiten. <br />
+            Neu erstellte Inhalte sind sofort freigegeben und damit öffentlich lesbar.
+          </td>
+        </tr>
+        <tr>
+          <td>Restricted</td>
+          <td>
+            Ein beschränkter Account kann neue Inhalte erstellen und diese lesen und bearbeiten. <br />
+            Neu erstellte Inhalte sind jedoch <strong>nicht</strong> freigegeben und können <strong>nicht</strong> von der Rolle 'App' gelesen werden.
+          </td>
+        </tr>
+        <tr>
+          <td>Editor</td>
+          <td>
+            Ein Editor kann neue Inhalte erstellen und eigene Inhalte lesen und bearbeiten. <br />
+            Neu erstellte Inhalte sind sofort freigegeben und damit öffentlich lesbar. <br />
+            Zudem kann er Inhalte von beschränkten Accounts lesen, bearbeiten und freigeben.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
     <h1>Nutzerverwaltung</h1>
 
     <p><%= link_to "Neuen Nutzer erstellen", new_account_path, class: 'btn btn-success' %></p>
@@ -25,7 +71,7 @@
             <td class="align-middle"><%= user.id %></td>
             <td class="align-middle"><%= link_to user.email, edit_account_path(user) %></td>
             <td class="align-middle"><%= user.data_provider.try(:name) %></td>
-            <td class="align-middle"><%= user.role %></td>
+            <td class="align-middle"><%= user.role.humanize %></td>
             <td class="align-middle">
               <span class="badge <%= user.try(:data_provider).try(:role_point_of_interest) ? 'badge-success' : 'badge-danger' %>">
                 <%= user.try(:data_provider).try(:role_point_of_interest) ? 'aktiv' : '' %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -40,7 +40,7 @@
           <td>
             Ein Editor kann neue Inhalte erstellen und eigene Inhalte lesen und bearbeiten. <br />
             Neu erstellte Inhalte sind sofort freigegeben und damit öffentlich lesbar. <br />
-            Zudem kann er Inhalte von beschränkten Accounts lesen, bearbeiten und freigeben.
+            Zudem kann er alle Inhalte von allen beschränkten Accounts lesen, bearbeiten und freigeben.
           </td>
         </tr>
       </tbody>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -31,7 +31,7 @@
         <tr>
           <td>Restricted</td>
           <td>
-            Ein beschränkter Account kann neue Inhalte erstellen und diese lesen und bearbeiten. <br />
+            Ein beschränkter Account kann neue Inhalte erstellen und eigene Inhalte lesen und bearbeiten. <br />
             Neu erstellte Inhalte sind jedoch <strong>nicht</strong> freigegeben und können <strong>nicht</strong> von der Rolle 'App' gelesen werden.
           </td>
         </tr>

--- a/app/views/layouts/doorkeeper/admin.html.erb
+++ b/app/views/layouts/doorkeeper/admin.html.erb
@@ -18,7 +18,7 @@
     <ul class="navbar-nav mr-auto">
       <% if current_user.admin_role? %>
         <li class="nav-item">
-          <%= link_to "Users", accounts_path, class: 'nav-link' %>
+          <%= link_to "Accounts", accounts_path, class: 'nav-link' %>
         </li>
 
         <li class="nav-item">

--- a/db/migrate/20201127102350_add_active_to_dataresources.rb
+++ b/db/migrate/20201127102350_add_active_to_dataresources.rb
@@ -1,0 +1,7 @@
+class AddActiveToDataresources < ActiveRecord::Migration[5.2]
+  def change
+    add_column :news_items, :visible, :boolean, default: true
+    add_column :event_records, :visible, :boolean, default: true
+    add_column :attractions, :visible, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_27_072145) do
+ActiveRecord::Schema.define(version: 2020_11_27_102350) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_11_27_072145) do
     t.datetime "updated_at", null: false
     t.string "type", default: "PointOfInterest", null: false
     t.integer "data_provider_id"
+    t.boolean "visible", default: true
   end
 
   create_table "attractions_certificates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -167,6 +168,7 @@ ActiveRecord::Schema.define(version: 2020_11_27_072145) do
     t.datetime "updated_at", null: false
     t.integer "data_provider_id"
     t.string "external_id"
+    t.boolean "visible", default: true
     t.index ["region_id"], name: "index_event_records_on_region_id"
   end
 
@@ -245,6 +247,7 @@ ActiveRecord::Schema.define(version: 2020_11_27_072145) do
     t.integer "data_provider_id"
     t.text "external_id"
     t.string "title"
+    t.boolean "visible", default: true
   end
 
   create_table "notification_devices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
Compared to destroyRecord, ther is a new mutaion to update the visibility aof an dataresource

`mutation { changeVisibility (id: 456, recordType: "NewsItem", visible: false){id, status, statusCode} }

![Bildschirmfoto 2020-11-27 um 16 26 32](https://user-images.githubusercontent.com/90779/100464135-5193c600-30cd-11eb-9b6f-c326c237999d.png)


Extend GraphQl to get status of  visibility for all 4 dataresources
![Bildschirmfoto 2020-11-27 um 16 27 03](https://user-images.githubusercontent.com/90779/100464169-64a69600-30cd-11eb-8e55-569f019f6609.png)

Backend extended for additional roles and added documentation:
![Bildschirmfoto 2020-11-27 um 16 30 07](https://user-images.githubusercontent.com/90779/100464462-f1e9ea80-30cd-11eb-9b86-c566d8bd82d8.png)
