### PR TITLE
Verknüpfung der DataResources untereinander

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem "jquery-rails"
 gem "jsoneditor-rails"
 gem "mailjet"
 
+gem "order_as_specified"
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    order_as_specified (1.6)
+      activerecord (>= 5.0.0)
     orm_adapter (0.5.0)
     parallel (1.17.0)
     parser (2.6.3.0)
@@ -415,6 +417,7 @@ DEPENDENCIES
   lograge
   mailjet
   mysql2 (>= 0.4.4, < 0.6.0)
+  order_as_specified
   puma (~> 3.12)
   rails (~> 5.2.4)
   rails-controller-testing

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -80,6 +80,7 @@ class AccountsController < ApplicationController
       data_provider_attributes: [
         :id,
         :name,
+        :data_type,
         :description,
         :role_point_of_interest,
         :role_tour,

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -28,7 +28,7 @@ class Resolvers::EventRecordsSearch
   option :limit, type: types.Int, with: :apply_limit
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
-  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
+  option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :take, type: types.Int, with: :apply_take
 
   def apply_category_id(scope, value)

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -28,6 +28,8 @@ class Resolvers::EventRecordsSearch
   option :limit, type: types.Int, with: :apply_limit
   option :take, type: types.Int, with: :apply_take
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
+  option :dataProvider, type: types.String, with: :apply_data_provider
+  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
 
   def apply_category_id(scope, value)
     scope.with_category(value)
@@ -49,6 +51,14 @@ class Resolvers::EventRecordsSearch
 
   def apply_take(scope, value)
     scope.take(value)
+  end
+
+  def apply_data_provider(scope, value)
+    scope.joins(:data_provider).where(data_providers: { name: value })
+  end
+
+  def apply_data_provider_id(scope, value)
+    scope.joins(:data_provider).where(data_providers: { id: value })
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -33,20 +33,14 @@ class Resolvers::EventRecordsSearch
 
   def apply_category_id(scope, value)
     scope.with_category(value)
-  rescue NoMethodError
-    scope.select { |event_record| event_record.category_ids.include?(value.to_i) }
   end
 
   def apply_skip(scope, value)
     scope.offset(value)
-  rescue NoMethodError
-    scope.drop(value)
   end
 
   def apply_limit(scope, value)
     scope.limit(value)
-  rescue NoMethodError
-    scope.first(value)
   end
 
   def apply_take(scope, value)
@@ -94,11 +88,15 @@ class Resolvers::EventRecordsSearch
   end
 
   def apply_order_with_list_date_desc(scope)
-    scope.sort_by(&:list_date).reverse
+    ordered_ids = scope.sort_by(&:list_date).reverse.map(&:id)
+
+    scope.order_as_specified(id: ordered_ids)
   end
 
   def apply_order_with_list_date_asc(scope)
-    scope.sort_by(&:list_date)
+    ordered_ids = scope.sort_by(&:list_date).map(&:id)
+
+    scope.order_as_specified(id: ordered_ids)
   end
 
   # https://github.com/nettofarah/graphql-query-resolver

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -26,10 +26,10 @@ class Resolvers::EventRecordsSearch
   option :categoryId, type: types.ID, with: :apply_category_id
   option :skip, type: types.Int, with: :apply_skip
   option :limit, type: types.Int, with: :apply_limit
-  option :take, type: types.Int, with: :apply_take
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.Int, with: :apply_data_provider_id
+  option :take, type: types.Int, with: :apply_take
 
   def apply_category_id(scope, value)
     scope.with_category(value)
@@ -43,9 +43,12 @@ class Resolvers::EventRecordsSearch
     scope.limit(value)
   end
 
+  # Achtung: Diese Methode liefert ein Array als Ergebnis
+  # und kann nicht weiter verkettet werden
   def apply_take(scope, value)
     scope.take(value)
   end
+  deprecate apply_take: :limit
 
   def apply_data_provider(scope, value)
     scope.joins(:data_provider).where(data_providers: { name: value })

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -25,6 +25,7 @@ class Resolvers::NewsItemsSearch
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: NewsItemsOrder, default: "publishedAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
+  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
   option :categoryId, type: types.ID, with: :apply_category_id
 
   def apply_limit(scope, value)
@@ -41,6 +42,10 @@ class Resolvers::NewsItemsSearch
 
   def apply_data_provider(scope, value)
     scope.joins(:data_provider).where(data_providers: { name: value })
+  end
+
+  def apply_data_provider_id(scope, value)
+    scope.joins(:data_provider).where(data_providers: { id: value })
   end
 
   def apply_category_id(scope, value)

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -25,7 +25,7 @@ class Resolvers::NewsItemsSearch
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: NewsItemsOrder, default: "publishedAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
-  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
+  option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :categoryId, type: types.ID, with: :apply_category_id
 
   def apply_limit(scope, value)

--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -25,6 +25,8 @@ class Resolvers::PointsOfInterestSearch
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: PointsOfInterestOrder, default: "createdAt_DESC"
+  option :dataProvider, type: types.String, with: :apply_data_provider
+  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
 
   def apply_limit(scope, value)
@@ -37,6 +39,14 @@ class Resolvers::PointsOfInterestSearch
 
   def apply_order(scope, value)
     scope.order(value)
+  end
+
+  def apply_data_provider(scope, value)
+    scope.joins(:data_provider).where(data_providers: { name: value })
+  end
+
+  def apply_data_provider_id(scope, value)
+    scope.joins(:data_provider).where(data_providers: { id: value })
   end
 
   def apply_category(scope, value)

--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -26,7 +26,7 @@ class Resolvers::PointsOfInterestSearch
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: PointsOfInterestOrder, default: "createdAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
-  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
+  option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
 
   def apply_limit(scope, value)

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -25,6 +25,8 @@ class Resolvers::ToursSearch
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: ToursOrder, default: "createdAt_DESC"
+  option :dataProvider, type: types.String, with: :apply_data_provider
+  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
 
   def apply_limit(scope, value)
@@ -37,6 +39,14 @@ class Resolvers::ToursSearch
 
   def apply_order(scope, value)
     scope.order(value)
+  end
+
+  def apply_data_provider(scope, value)
+    scope.joins(:data_provider).where(data_providers: { name: value })
+  end
+
+  def apply_data_provider_id(scope, value)
+    scope.joins(:data_provider).where(data_providers: { id: value })
   end
 
   def apply_category(scope, value)

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -26,7 +26,7 @@ class Resolvers::ToursSearch
   option :skip, type: types.Int, with: :apply_skip
   option :order, type: ToursOrder, default: "createdAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
-  option :dataProviderId, type: types.Int, with: :apply_data_provider_id
+  option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
 
   def apply_limit(scope, value)

--- a/app/graphql/types/data_provider_input.rb
+++ b/app/graphql/types/data_provider_input.rb
@@ -3,6 +3,7 @@
 module Types
   class DataProviderInput < BaseInputObject
     argument :name, String, required: true
+    argument :data_type, String, required: false
     argument :address, Types::AddressInput, required: false,
                                             as: :address_attributes,
                                             prepare: ->(address, _ctx) { address.to_h }

--- a/app/graphql/types/data_provider_type.rb
+++ b/app/graphql/types/data_provider_type.rb
@@ -4,6 +4,7 @@ module Types
   class DataProviderType < Types::BaseObject
     field :id, ID, null: true
     field :name, String, null: true
+    field :data_type, String, null: true
     field :logo, WebUrlType, null: true
     field :description, String, null: true
     field :address, AddressType, null: true

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -2,6 +2,7 @@
 
 class DataProvider < ApplicationRecord
   store :roles, accessors: %i[role_point_of_interest role_tour role_news_item role_event_record role_push_notification], coder: JSON
+  enum data_type: { general_importer: 0, business_account: 1 }, _suffix: :role
 
   has_many :data_resource_settings, class_name: "DataResourceSetting"
   has_many :news_items

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -2,6 +2,8 @@
 
 # this model describes the data for an event e.g. a concert or a reading.
 class EventRecord < ApplicationRecord
+  extend OrderAsSpecified
+
   attr_accessor :category_name
   attr_accessor :region_name
   attr_accessor :force_create

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -69,6 +69,15 @@
     </small>
   </div>
 
+  <div class="form-group">
+    <%= d.label :data_type, "Art des Datenlieferanten" %>
+    <%= d.select :data_type, DataProvider.data_types.keys.map { |a| [a.humanize, a] }, {}, class: "form-control" %>
+    <small class="form-text text-muted">
+      Bei einem BusinessAccount werden in der App Nachrichten, Veranstaltungen, Touren und Orte verknüpft dargestellt.
+      D.h. in der Detailansicht eines Standortes werden darunter alle Nachrichten und Events dieses Datenlieferanten angezeigt.
+    </small>
+  </div>
+
   <h3>Logo</h3>
   <%= d.fields_for :logo, object: @user.data_provider.logo || @user.data_provider.build_logo do |l| %>
     <div class="form-group">

--- a/db/migrate/20201201122547_add_datatype_to_data_providers.rb
+++ b/db/migrate/20201201122547_add_datatype_to_data_providers.rb
@@ -1,0 +1,5 @@
+class AddDatatypeToDataProviders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :data_providers, :data_type, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_27_072145) do
+ActiveRecord::Schema.define(version: 2020_12_01_122547) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_11_27_072145) do
     t.datetime "updated_at", null: false
     t.string "type", default: "PointOfInterest", null: false
     t.integer "data_provider_id"
+    t.boolean "visible", default: true
   end
 
   create_table "attractions_certificates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -139,6 +140,7 @@ ActiveRecord::Schema.define(version: 2020_11_27_072145) do
     t.datetime "updated_at", null: false
     t.text "always_recreate"
     t.text "roles"
+    t.integer "data_type", default: 0
   end
 
   create_table "data_resource_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -167,6 +169,7 @@ ActiveRecord::Schema.define(version: 2020_11_27_072145) do
     t.datetime "updated_at", null: false
     t.integer "data_provider_id"
     t.string "external_id"
+    t.boolean "visible", default: true
     t.index ["region_id"], name: "index_event_records_on_region_id"
   end
 
@@ -245,6 +248,7 @@ ActiveRecord::Schema.define(version: 2020_11_27_072145) do
     t.integer "data_provider_id"
     t.text "external_id"
     t.string "title"
+    t.boolean "visible", default: true
   end
 
   create_table "notification_devices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
Ziel ist es, dass bei einem POI eines Datenlieferanten alle News und Events des gleichen Datenlieferanten dargestellt werden können.

Hierzu gibt es nun neue Filteroptionen in allen DataResources nach dem Namen und der ID des DataProviders (dataProvider, dataProviderId)

Die Information, ob eine Standort verknüpfte Daten anzeigen soll, hängt ebenfalls am DataProvider: data_type
Der Datentyp ist entweder 'general_importer' oder 'business_account', wobei der BusinessAccount derjenige ist, der eine Repräsentation zu einer Firma darstellen soll, bei der dann News und Events mit dargestellt werden sollen.

![Bildschirmfoto 2020-12-01 um 13 39 25](https://user-images.githubusercontent.com/90779/100744873-c07b6280-33de-11eb-9711-85e2c5f7bee5.png)
![Bildschirmfoto 2020-12-01 um 13 46 12](https://user-images.githubusercontent.com/90779/100744877-c113f900-33de-11eb-8a98-ec548974a9ae.png)
