### PR TITLE
Genauigkeit der GeoDaten verbessert

### DIFF
--- a/db/migrate/20201203145226_fix_precision_in_geo_locations.rb
+++ b/db/migrate/20201203145226_fix_precision_in_geo_locations.rb
@@ -1,0 +1,6 @@
+class FixPrecisionInGeoLocations < ActiveRecord::Migration[5.2]
+  def change
+    change_column :geo_locations, :latitude, :double
+    change_column :geo_locations, :longitude, :double
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_122547) do
+ActiveRecord::Schema.define(version: 2020_12_03_145226) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -198,8 +198,8 @@ ActiveRecord::Schema.define(version: 2020_12_01_122547) do
   end
 
   create_table "geo_locations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.float "latitude"
-    t.float "longitude"
+    t.float "latitude", limit: 53
+    t.float "longitude", limit: 53
     t.string "geo_locateable_type"
     t.bigint "geo_locateable_id"
     t.datetime "created_at", null: false


### PR DESCRIPTION
Die vorhandenen GeoDaten waren als Float in der Datenbank codiert, sodass nach 4 Stellen hinter dem Komma gerundet wurde.

Der Wechsel zu einem Double erhöht die Anzahl der Stellen hinter dem Komma und damit die Genauigkeit der GeoCoordinaten.

Erstaunlicherweise sind die genaueren Werte auch bereits in der DB gespeichert.

![Bildschirmfoto 2020-12-03 um 16 15 56](https://user-images.githubusercontent.com/90779/101048676-1db01900-3583-11eb-88ef-2a28e74070e5.png)