### PR TITLE
Filter Newsitem for given ID

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -26,6 +26,7 @@ class Resolvers::EventRecordsSearch
   option :categoryId, type: types.ID, with: :apply_category_id
   option :skip, type: types.Int, with: :apply_skip
   option :limit, type: types.Int, with: :apply_limit
+  option :ids, type: types[types.ID], with: :apply_ids
   option :order, type: EventRecordsOrder, default: "createdAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
@@ -41,6 +42,10 @@ class Resolvers::EventRecordsSearch
 
   def apply_limit(scope, value)
     scope.limit(value)
+  end
+
+  def apply_ids(scope, value)
+    scope.where(id: value)
   end
 
   # Achtung: Diese Methode liefert ein Array als Ergebnis

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -23,6 +23,7 @@ class Resolvers::NewsItemsSearch
 
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
+  option :ids, type: types[types.ID], with: :apply_ids
   option :order, type: NewsItemsOrder, default: "publishedAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
@@ -34,6 +35,10 @@ class Resolvers::NewsItemsSearch
 
   def apply_skip(scope, value)
     scope.offset(value)
+  end
+
+  def apply_ids(scope, value)
+    scope.where(id: value)
   end
 
   def apply_order(scope, value)

--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -24,6 +24,7 @@ class Resolvers::PointsOfInterestSearch
 
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
+  option :ids, type: types[types.ID], with: :apply_ids
   option :order, type: PointsOfInterestOrder, default: "createdAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
@@ -35,6 +36,10 @@ class Resolvers::PointsOfInterestSearch
 
   def apply_skip(scope, value)
     scope.offset(value)
+  end
+
+  def apply_ids(scope, value)
+    scope.where(id: value)
   end
 
   def apply_order(scope, value)

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -24,6 +24,7 @@ class Resolvers::ToursSearch
 
   option :limit, type: types.Int, with: :apply_limit
   option :skip, type: types.Int, with: :apply_skip
+  option :ids, type: types[types.ID], with: :apply_ids
   option :order, type: ToursOrder, default: "createdAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
@@ -35,6 +36,10 @@ class Resolvers::ToursSearch
 
   def apply_skip(scope, value)
     scope.offset(value)
+  end
+
+  def apply_ids(scope, value)
+    scope.where(id: value)
   end
 
   def apply_order(scope, value)


### PR DESCRIPTION
Liste an IDs zum Filtern kann nun an SearchQuerys mitgegeben werden.

query { newsItems (ids: [434,429]){id, author …

Richtige Syntax hier gefunden: https://github.com/rmosolgo/graphql-ruby/issues/1895

![Bildschirmfoto 2020-12-09 um 16 31 15](https://user-images.githubusercontent.com/90779/101650228-04541480-3a3c-11eb-9930-78ca01ede264.png)
