### PR TITLE
feat: allow multiple categories for mutations

### DIFF
--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -17,6 +17,11 @@ module Mutations
                                                                       repeat_duration.to_h
                                                                     }
     argument :category_name, String, required: false
+    argument :categories, [Types::CategoryInput], required: false,
+                                                  as: :category_names,
+                                                  prepare: lambda { |category, _ctx|
+                                                             category.map(&:to_h)
+                                                           }
     argument :region_name, String, required: false
     argument :region, Types::RegionInput, required: false
     argument :addresses, [Types::AddressInput], required: false,

--- a/app/graphql/mutations/create_point_of_interest.rb
+++ b/app/graphql/mutations/create_point_of_interest.rb
@@ -8,6 +8,11 @@ module Mutations
     argument :mobile_description, String, required: false
     argument :active, Boolean, required: false
     argument :category_name, String, required: false
+    argument :categories, [Types::CategoryInput], required: false,
+                                                  as: :category_names,
+                                                  prepare: lambda { |category, _ctx|
+                                                             category.map(&:to_h)
+                                                           }
     argument :addresses, [Types::AddressInput], required: false,
                                                 as: :addresses_attributes,
                                                 prepare: lambda { |addresses, _ctx|

--- a/app/graphql/mutations/create_tour.rb
+++ b/app/graphql/mutations/create_tour.rb
@@ -8,6 +8,11 @@ module Mutations
     argument :mobile_description, String, required: false
     argument :active, Boolean, required: false
     argument :category_name, String, required: false
+    argument :categories, [Types::CategoryInput], required: false,
+                                                  as: :category_names,
+                                                  prepare: lambda { |category, _ctx|
+                                                             category.map(&:to_h)
+                                                           }
     argument :addresses, [Types::AddressInput], required: false,
                                                 as: :addresses_attributes,
                                                 prepare: lambda { |addresses, _ctx|

--- a/app/models/data_resources/attraction.rb
+++ b/app/models/data_resources/attraction.rb
@@ -5,6 +5,7 @@
 #
 class Attraction < ApplicationRecord
   attr_accessor :category_name
+  attr_accessor :category_names
 
   after_save :find_or_create_category
 
@@ -29,24 +30,35 @@ class Attraction < ApplicationRecord
                                 :data_provider, :certificates,
                                 :regions
 
-  #
-  # callback function which enables setting of category by
-  # virtual attribute category name. ATTENTION: With this callback
-  # the setting of category is only possible with category_name
-  # PointOfInterest.create(category: Category.first) doesn't work anymore.
-  #
-  def find_or_create_category
-    return if category_name.blank?
-
-    category_to_add = Category.where(name: category_name).first_or_create
-    categories << category_to_add unless categories.include?(category_to_add)
-  end
-
   # Sicherstellung der Abwärtskompatibilität seit 09/2020
   def category
     ActiveSupport::Deprecation.warn(":category is replaced by has_many :categories")
     categories.first
   end
+
+  private
+
+    # callback function which enables setting of category by
+    # virtual attribute category name.
+    # ATTENTION: With this callback the setting of category is only possible with category_name.
+    #            PointOfInterest.create(category: Category.first) doesn't work anymore.
+    def find_or_create_category
+      # für Abwärtskompatibilität, wenn nur ein einiger Kategorienamen angegeben wird
+      # ist der attr_accessor :category_name befüllt
+      if category_name.present?
+        category_to_add = Category.where(name: category_name).first_or_create
+        categories << category_to_add unless categories.include?(category_to_add)
+      end
+
+      # Wenn mehrere Kategorein auf einmal gesetzt werden
+      # ist der attr_accessor :category_names befüllt
+      if category_names.present?
+        category_names.each do |cat|
+          category_to_add = Category.where(name: cat[:name]).first_or_create
+          categories << category_to_add unless categories.include?(category_to_add)
+        end
+      end
+    end
 end
 
 # == Schema Information

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -6,6 +6,7 @@ class EventRecord < ApplicationRecord
   extend OrderAsSpecified
 
   attr_accessor :category_name
+  attr_accessor :category_names
   attr_accessor :region_name
   attr_accessor :force_create
 
@@ -79,13 +80,6 @@ class EventRecord < ApplicationRecord
 
   validates_presence_of :title
 
-  def find_or_create_category
-    return if category_name.blank?
-
-    category_to_add = Category.where(name: category_name).first_or_create
-    categories << category_to_add unless categories.include?(category_to_add)
-  end
-
   def find_or_create_region
     self.region_id = Region.where(name: region_name).first_or_create.id
   end
@@ -136,6 +130,24 @@ class EventRecord < ApplicationRecord
   end
 
   private
+
+    def find_or_create_category
+      # für Abwärtskompatibilität, wenn nur ein einiger Kategorienamen angegeben wird
+      # ist der attr_accessor :category_name befüllt
+      if category_name.present?
+        category_to_add = Category.where(name: category_name).first_or_create
+        categories << category_to_add unless categories.include?(category_to_add)
+      end
+
+      # Wenn mehrere Kategorein auf einmal gesetzt werden
+      # ist der attr_accessor :category_names befüllt
+      if category_names.present?
+        category_names.each do |cat|
+          category_to_add = Category.where(name: cat[:name]).first_or_create
+          categories << category_to_add unless categories.include?(category_to_add)
+        end
+      end
+    end
 
     # need to check start and end date and return "today" if there is only one date.
     # per CMS only one date can be saved.


### PR DESCRIPTION
- added possibility to perform mutations for multiple categories for event records, points of interest, tours
- copied logics from news items
- made callback methods private

Closes #181