### PR TITLE
Compare of changed attributes per resource

### DIFF
--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -101,10 +101,19 @@ class EventRecord < ApplicationRecord
     generate_checksum(fields + address_fields + date_fields)
   end
 
+  def compareable_attributes
+    except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id", "dateable_id"]
+
+    list_of_attributes = {}
+    list_of_attributes.merge!(attributes.except(*except_attributes))
+    list_of_attributes.merge!(dates: dates.map { |date| date.attributes.except(*except_attributes) })
+
+    list_of_attributes
+  end
+
   def list_date
     event_dates = dates.order(date_start: :asc)
     dates_count = event_dates.count
-
     return if dates_count.zero?
 
     future_dates = event_dates.select do |date|
@@ -113,7 +122,6 @@ class EventRecord < ApplicationRecord
     future_date = future_dates.first.try(:date_start)
 
     return future_date if future_date.present?
-
     return today_in_time_range(event_dates.first) if dates_count == 1
 
     event_dates.last.try(:date_start)

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -53,7 +53,9 @@ class ResourceService
 
   def unchanged_attributes?(record)
     return false if record.blank?
+    return @resource.compareable_attributes == record.compareable_attributes if record.respond_to?(:compareable_attributes)
 
+    # Fallback, wenn :compareable_attributes nicht beim Model definiert ist.
     except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id"]
     @resource.attributes.except(*except_attributes) == record.attributes.except(*except_attributes)
   end


### PR DESCRIPTION
- Every resourcemodel can have a method :compareable_attributes
  which returns a hash of attributes to determine changes
- Fallback will be the currently compared attributes
- for the model EventRecord :compareable_attributes is defined
  to also include the attributes of the first date fields