### PR TITLE
Feature/206 cleanup old data

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -117,6 +117,7 @@ class AccountsController < ApplicationController
           :data_provider_id,
           :only_summary_link_text,
           :convert_media_urls_to_external_storage,
+          :cleanup_old_records,
           default_category_ids: []
         ]
       ]

--- a/app/models/data_resource_setting.rb
+++ b/app/models/data_resource_setting.rb
@@ -10,6 +10,7 @@ class DataResourceSetting < ApplicationRecord
           only_summary_link_text
           convert_media_urls_to_external_storage
           default_category_ids
+          cleanup_old_records
         ],
         coder: JSON
 

--- a/app/services/clean_up_service.rb
+++ b/app/services/clean_up_service.rb
@@ -1,0 +1,45 @@
+class CleanUpService
+  def initialize
+    @data_resource_types = DataResourceSetting::DATA_RESOURCES
+    accounts = User.includes(:data_provider).all
+    @data_providers = accounts.map(&:data_provider)
+  end
+
+  def perform
+    @data_providers.each do |data_provider|
+      @data_resource_types.each do |data_resource_type|
+        resource_configs = data_provider.data_resource_settings.where(data_resource_type: data_resource_type.to_s).first
+        next if resource_configs.blank?
+        next if resource_configs.settings.blank?
+
+        cleanup_records = resource_configs.settings.fetch("cleanup_old_records", "false") == "true"
+        next unless cleanup_records
+
+        # die Ressourcen vom aktuellen data_provider und data_resource_type sollen bereinigt werden
+        p "Cleanup records for data_provider #{data_provider.id} and #{data_resource_type}"
+        cleanup_records_for(data_provider, data_resource_type)
+      end
+    end
+  end
+
+  def cleanup_records_for(data_provider, data_resource_type)
+    latest_import_date = ExternalReference
+                           .where(data_provider_id: data_provider.id, external_type: data_resource_type.to_s)
+                           .order(:updated_at)
+                           .last
+                           .updated_at
+
+    # Mitternacht, 2 Tage vor dem letzten Import
+    cleanup_records_to_date = (latest_import_date - 2.days).end_of_day
+    external_references = ExternalReference.where(data_provider_id: data_provider.id, external_type: data_resource_type.to_s)
+    resource_ids = external_references.where("updated_at < ?", cleanup_records_to_date).pluck(:external_id)
+
+    p "Deleting #{resource_ids.count} records of #{data_resource_type}"
+
+    # cancel deletion if all data of this data_provider would be deleted
+    return if external_references.count == resource_ids.count
+
+    data_resource_type.where(id: resource_ids).destroy_all
+  end
+
+end

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -238,11 +238,13 @@
 
     <div class="row">
       <div class="form-group col-6">
-        <%= s.label :only_summary_link_text, "Linktext" %>
-        <%= s.text_field :only_summary_link_text, class: "form-control", placeholder: "Weiterlesen" %>
-        <small class="form-text text-muted">
-          Dieser Text wird angezeigt, wenn die Checkbox 'Nur Zusammenfassung anzeigen' aktiviert ist.
-        </small>
+        <div class="form-check">
+          <%= s.check_box :cleanup_old_records, { class: "form-check-input"}, "true", "false" %>
+          <%= s.label :cleanup_old_records, "Alte Daten regelmäßig löschen", class: "form-check-label" %>
+          <small class="form-text text-muted">
+            Täglich werden Daten diesen Typs gelöscht, wenn diese mehr als 48 Stunden älter sind als der zuletzt importierte Datensatz.
+          </small>
+        </div>
       </div>
 
       <div class="form-group col-6">
@@ -276,6 +278,15 @@
               ) %>
         </small>
       </div>
+
+      <div class="form-group col-6">
+        <%= s.label :only_summary_link_text, "Linktext" %>
+        <%= s.text_field :only_summary_link_text, class: "form-control", placeholder: "Weiterlesen" %>
+        <small class="form-text text-muted">
+          Dieser Text wird angezeigt, wenn die Checkbox 'Nur Zusammenfassung anzeigen' aktiviert ist.
+        </small>
+      </div>
+
     </div>
   <% end %>
 <% end %>

--- a/bin/start-cron.sh
+++ b/bin/start-cron.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 bundle exec rails runner "WasteNotification.new.send_notifications"
+bundle exec rails runner "CleanUpService.new.perform"


### PR DESCRIPTION
### Update external_resource on import

Wenn eine Resource neu angelegt wird, wird bisher die zugehörige ExternalReference neu angelegt und damit auch das updated_at neu gesetzt.

Jetzt wird zusätzlich das updated_at von ExternalReference auch neu gesetzt, wenn kein Update an der Resource notwendig ist.
D.h. jedesmal wenn ein Importer einen Datensatz aktualisieren will, aber sich herausstellt, dass dieser Datensatz lokal bereits existiert und aktuell ist, wird dennoch das updated_at der zugehörigen ExternalReference aktualisiert.

### cleanup_old_data einstellbar pro Dataprovider und pro ResourceType

Dieses Datumsfeld wird im späteren verlauf verwendet werden um über einen cronjob alte Datensätze zu löschen.

Für jede Resource eines Datenlieferanten kann definiert werden, ob alte Daten regelmäßig gelöscht werden sollen

![Bildschirmfoto 2021-03-11 um 13 29 59](https://user-images.githubusercontent.com/90779/110798392-6b22dd00-827a-11eb-99a6-937da4f2bb92.png)

### Lösche alte Daten per Cronjob

Für jede Datenlieferanten werden für jede Resource alle alten Daten herausgesucht und gelöscht, sofern dies in den ResourceSettings aktiviert ist.

Falls alle Daten gelöscht werden würde, wird vorher abgebrochen.