### PR TITLE
feat(account): add roles for jobs, offers and construction sites

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -86,9 +86,12 @@ class AccountsController < ApplicationController
         :role_tour,
         :role_news_item,
         :role_event_record,
-        :role_waste_calendar,
         :role_push_notification,
         :role_lunch,
+        :role_waste_calendar,
+        :role_job,
+        :role_offer,
+        :role_constuction_site,
         logo_attributes: %i[
           id
           url

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
 
 class DataProvider < ApplicationRecord
-  store :roles, accessors: %i[role_point_of_interest role_tour role_news_item role_event_record role_push_notification role_lunch role_waste_calendar], coder: JSON
+  store :roles,
+        accessors: %i[
+          role_point_of_interest
+          role_tour
+          role_news_item
+          role_event_record
+          role_push_notification
+          role_lunch
+          role_waste_calendar
+          role_job
+          role_offer
+          role_constuction_site
+        ],
+        coder: JSON
   enum data_type: { general_importer: 0, business_account: 1 }, _suffix: :role
 
   has_many :data_resource_settings, class_name: "DataResourceSetting"

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -206,6 +206,27 @@
     </div>
   </div>
 
+  <div class="form-group">
+    <div class="form-check">
+      <%= d.check_box :role_job, { class: "form-check-input" }, "true", "false" %>
+      <%= d.label :role_job, "Stellenanzeigen", class: "form-check-label" %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-check">
+      <%= d.check_box :role_offer, { class: "form-check-input" }, "true", "false" %>
+      <%= d.label :role_offer, "Werbliche Anzeigen", class: "form-check-label" %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <div class="form-check">
+      <%= d.check_box :role_constuction_site, { class: "form-check-input" }, "true", "false" %>
+      <%= d.label :role_constuction_site, "Baustellen", class: "form-check-label" %>
+    </div>
+  </div>
+
   <%= d.fields_for :data_resource_settings do |s| %>
     <% I18n.with_locale(:de) do %>
       <h2>Optionen für <%= t(s.object.data_resource_type.pluralize) if s.object.data_resource_type %></h2>


### PR DESCRIPTION
- added more accessors to `roles` store of `DataProvider` to be able to save and make more data types depending on the roles

![Bildschirmfoto 2021-03-11 um 15 25 36](https://user-images.githubusercontent.com/1942953/110801981-0b2e3580-827e-11eb-86d5-8623a78ed9f5.png)
