### PR TITLE
fix: correct graphql types

### DIFF
--- a/app/graphql/resolvers/waste_location_search.rb
+++ b/app/graphql/resolvers/waste_location_search.rb
@@ -8,7 +8,7 @@ class Resolvers::WasteLocationSearch
 
   scope { Address.where(id: Waste::LocationType.all.pluck(:address_id)) }
 
-  type types[Types::AddressType]
+  type types[Types::QueryTypes::AddressType]
 
   class WasteLocationOrder < ::Types::BaseEnum
     value "createdAt_ASC"
@@ -70,7 +70,7 @@ class Resolvers::WasteLocationSearch
     # NOTE: Don't run QueryResolver during tests
     return super unless context.present?
 
-    GraphQL::QueryResolver.run(Address, context, Types::AddressType) do
+    GraphQL::QueryResolver.run(Address, context, Types::QueryTypes::AddressType) do
       super
     end
   end

--- a/app/graphql/types/input_types/waste_location_type_input.rb
+++ b/app/graphql/types/input_types/waste_location_type_input.rb
@@ -4,7 +4,7 @@ module Types
   class InputTypes::WasteLocationTypeInput < BaseInputObject
     argument :waste_type, String, required: false
     argument :address_id, Integer, required: false
-    argument :address, Types::AddressInput, required: false,
+    argument :address, Types::InputTypes::AddressInput, required: false,
                                             as: :address_attributes,
                                             prepare: lambda { |address, _ctx|
                                                        address.to_h

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -37,7 +37,7 @@ module Types
     field :categories, [QueryTypes::CategoryType], null: false
     field :category_tree, GraphQL::Types::JSON, null: false
 
-    field :waste_addresses, [AddressType], function: Resolvers::WasteLocationSearch
+    field :waste_addresses, [QueryTypes::AddressType], function: Resolvers::WasteLocationSearch
     field :waste_location_types, [QueryTypes::WasteLocationTypeType], null: false
     field :waste_location_type, QueryTypes::WasteLocationTypeType, null: false do
       argument :id, ID, required: true

--- a/app/graphql/types/query_types/waste_location_type_type.rb
+++ b/app/graphql/types/query_types/waste_location_type_type.rb
@@ -6,7 +6,7 @@ module Types
     field :waste_type, String, null: true
     field :list_pick_up_dates, [String], null: true
     field :pick_up_times, [QueryTypes::WastePickUpTimeType], null: true
-    field :address, AddressType, null: true
+    field :address, QueryTypes::AddressType, null: true
     field :address_id, Integer, null: true
     field :updated_at, String, null: true
     field :created_at, String, null: true

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -18,6 +18,7 @@ type Address {
   id: ID
   kind: String
   street: String
+  wasteLocationTypes: [WasteLocationType!]
   zip: String
 }
 
@@ -232,6 +233,7 @@ input GenericItemInput {
   contentBlocks: [ContentBlockInput!]
   dates: [DateInput!]
   externalId: String
+  forceCreate: Boolean
   genericItems: [GenericItemInput!]
   genericType: String
   locations: [LocationInput!]
@@ -251,6 +253,8 @@ enum GenericItemOrder {
   createdAt_DESC
   id_ASC
   id_DESC
+  publicationDate_ASC
+  publicationDate_DESC
   publishedAt_ASC
   publishedAt_DESC
   updatedAt_ASC
@@ -357,10 +361,11 @@ type Mutation {
   changeVisibility(id: ID!, recordType: String!, visible: Boolean!): ChangeVisibility!
   createAppUserContent(content: String, dataSource: String, dataType: String): AppUserContent!
   createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
-  createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
+  createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, forceCreate: Boolean, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
   createNewsItem(address: AddressInput, author: String, categories: [CategoryInput!], categoryName: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], externalId: String, forceCreate: Boolean, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, pushNotification: Boolean, showPublishDate: Boolean, sourceUrl: WebUrlInput, title: String): NewsItem!
   createPointOfInterest(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, location: LocationInput, lunches: [LunchInput!], mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, openingHours: [OpeningHourInput!], operatingCompany: OperatingCompanyInput, priceInformations: [PriceInput!], tags: [String!], webUrls: [WebUrlInput!]): PointOfInterest!
   createTour(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, geometryTourData: [GeoLocationInput!], lengthKm: Int!, location: LocationInput, meansOfTransportation: String, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, operatingCompany: OperatingCompanyInput, tags: [String!], webUrls: [WebUrlInput!]): Tour!
+  createWastePickUpTime(pickupDate: String!, wasteLocationType: WasteLocationTypeInput, wasteLocationTypeId: Int): WastePickUpTime!
   destroyRecord(externalId: Int, id: Int, recordType: String!): Destroy!
 }
 
@@ -378,6 +383,7 @@ type NewsItem {
   newsType: String
   publicationDate: String
   publishedAt: String
+  pushNotificationsSentAt: String
   settings: Setting
   showPublishDate: Boolean
   sourceUrl: WebUrl
@@ -551,6 +557,9 @@ type Query {
   publicJsonFile(name: String!): PublicJsonFile!
   tour(id: ID!): Tour!
   tours(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
+  wasteAddresses(ids: [ID], limit: Int, order: WasteLocationOrder = createdAt_DESC, skip: Int): [Address!]!
+  wasteLocationType(id: ID!): WasteLocationType!
+  wasteLocationTypes: [WasteLocationType!]!
   weatherMap(id: ID): OpenWeatherMap!
   weatherMaps(ids: [ID], limit: Int, order: OpenWeatherMapsOrder = createdAt_DESC, skip: Int): [OpenWeatherMap]
 }
@@ -619,6 +628,41 @@ enum ToursOrder {
   name_DESC
   updatedAt_ASC
   updatedAt_DESC
+}
+
+enum WasteLocationOrder {
+  createdAt_ASC
+  createdAt_DESC
+  id_ASC
+  id_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+}
+
+type WasteLocationType {
+  address: Address
+  addressId: Int
+  createdAt: String
+  id: ID
+  listPickUpDates: [String!]
+  pickUpTimes: [WastePickUpTime!]
+  updatedAt: String
+  wasteType: String
+}
+
+input WasteLocationTypeInput {
+  address: AddressInput
+  addressId: Int
+  wasteType: String
+}
+
+type WastePickUpTime {
+  createdAt: String
+  id: ID
+  pickupDate: String
+  updatedAt: String
+  wasteLocationType: WasteLocationType
+  wasteLocationTypeId: ID
 }
 
 type WebUrl {

--- a/public/schema.json
+++ b/public/schema.json
@@ -979,6 +979,132 @@
               "deprecationReason": null
             },
             {
+              "name": "wasteAddresses",
+              "description": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "order",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "WasteLocationOrder",
+                    "ofType": null
+                  },
+                  "defaultValue": "createdAt_DESC"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Address",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationType",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WasteLocationType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationTypes",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "WasteLocationType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "weatherMap",
               "description": null,
               "args": [
@@ -1787,6 +1913,28 @@
               "deprecationReason": null
             },
             {
+              "name": "wasteLocationTypes",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WasteLocationType",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "zip",
               "description": null,
               "args": [
@@ -1867,6 +2015,254 @@
           "kind": "SCALAR",
           "name": "Float",
           "description": "Represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WasteLocationType",
+          "description": null,
+          "fields": [
+            {
+              "name": "address",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Address",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "addressId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listPickUpDates",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pickUpTimes",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WastePickUpTime",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteType",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WastePickUpTime",
+          "description": null,
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pickupDate",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationType",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "WasteLocationType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationTypeId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -2091,16 +2487,6 @@
           "interfaces": [
 
           ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -4993,6 +5379,20 @@
               "deprecationReason": null
             },
             {
+              "name": "pushNotificationsSentAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "settings",
               "description": null,
               "args": [
@@ -5246,6 +5646,18 @@
               "deprecationReason": null
             },
             {
+              "name": "publicationDate_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicationDate_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "publishedAt_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5456,18 +5868,6 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updatedAt_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5475,6 +5875,18 @@
             },
             {
               "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5503,13 +5915,13 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
+              "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_DESC",
+              "name": "id_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5527,19 +5939,19 @@
               "deprecationReason": null
             },
             {
-              "name": "id_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5568,13 +5980,25 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
+              "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_DESC",
+              "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listDate_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listDate_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5592,25 +6016,13 @@
               "deprecationReason": null
             },
             {
-              "name": "id_ASC",
+              "name": "updatedAt_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "id_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "listDate_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "listDate_ASC",
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5639,13 +6051,13 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
+              "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_DESC",
+              "name": "id_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5663,13 +6075,13 @@
               "deprecationReason": null
             },
             {
-              "name": "id_ASC",
+              "name": "updatedAt_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "id_DESC",
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5680,6 +6092,71 @@
         {
           "kind": "ENUM",
           "name": "ToursOrder",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "createdAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "WasteLocationOrder",
           "description": null,
           "fields": null,
           "inputFields": null,
@@ -5710,18 +6187,6 @@
               "deprecationReason": null
             },
             {
-              "name": "name_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5729,12 +6194,6 @@
             },
             {
               "name": "id_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RAND",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5853,18 +6312,6 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updatedAt_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5872,6 +6319,18 @@
             },
             {
               "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -6285,6 +6744,16 @@
               "name": "createGenericItem",
               "description": null,
               "args": [
+                {
+                  "name": "forceCreate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "pushNotification",
                   "description": null,
@@ -7370,6 +7839,57 @@
               "deprecationReason": null
             },
             {
+              "name": "createWastePickUpTime",
+              "description": null,
+              "args": [
+                {
+                  "name": "pickupDate",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "wasteLocationTypeId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "wasteLocationType",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WasteLocationTypeInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WastePickUpTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "destroyRecord",
               "description": null,
               "args": [
@@ -7817,6 +8337,16 @@
           "description": null,
           "fields": null,
           "inputFields": [
+            {
+              "name": "forceCreate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
             {
               "name": "pushNotification",
               "description": null,
@@ -8885,6 +9415,47 @@
           "interfaces": [
 
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "WasteLocationTypeInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "wasteType",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "address",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddressInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,6 +18,7 @@ type Address {
   id: ID
   kind: String
   street: String
+  wasteLocationTypes: [WasteLocationType!]
   zip: String
 }
 
@@ -232,6 +233,7 @@ input GenericItemInput {
   contentBlocks: [ContentBlockInput!]
   dates: [DateInput!]
   externalId: String
+  forceCreate: Boolean
   genericItems: [GenericItemInput!]
   genericType: String
   locations: [LocationInput!]
@@ -251,6 +253,8 @@ enum GenericItemOrder {
   createdAt_DESC
   id_ASC
   id_DESC
+  publicationDate_ASC
+  publicationDate_DESC
   publishedAt_ASC
   publishedAt_DESC
   updatedAt_ASC
@@ -357,10 +361,11 @@ type Mutation {
   changeVisibility(id: ID!, recordType: String!, visible: Boolean!): ChangeVisibility!
   createAppUserContent(content: String, dataSource: String, dataType: String): AppUserContent!
   createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
-  createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
+  createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, forceCreate: Boolean, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
   createNewsItem(address: AddressInput, author: String, categories: [CategoryInput!], categoryName: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], externalId: String, forceCreate: Boolean, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, pushNotification: Boolean, showPublishDate: Boolean, sourceUrl: WebUrlInput, title: String): NewsItem!
   createPointOfInterest(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, location: LocationInput, lunches: [LunchInput!], mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, openingHours: [OpeningHourInput!], operatingCompany: OperatingCompanyInput, priceInformations: [PriceInput!], tags: [String!], webUrls: [WebUrlInput!]): PointOfInterest!
   createTour(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, geometryTourData: [GeoLocationInput!], lengthKm: Int!, location: LocationInput, meansOfTransportation: String, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, operatingCompany: OperatingCompanyInput, tags: [String!], webUrls: [WebUrlInput!]): Tour!
+  createWastePickUpTime(pickupDate: String!, wasteLocationType: WasteLocationTypeInput, wasteLocationTypeId: Int): WastePickUpTime!
   destroyRecord(externalId: Int, id: Int, recordType: String!): Destroy!
 }
 
@@ -378,6 +383,7 @@ type NewsItem {
   newsType: String
   publicationDate: String
   publishedAt: String
+  pushNotificationsSentAt: String
   settings: Setting
   showPublishDate: Boolean
   sourceUrl: WebUrl
@@ -534,6 +540,7 @@ type PublicJsonFile {
 
 type Query {
   categories: [Category!]!
+  categoryTree: JSON!
   directus(query: String): JSON!
   eventRecord(id: ID!): EventRecord!
   eventRecords(categoryId: ID, dataProvider: String, dataProviderId: ID, dateRange: [String], ids: [ID], limit: Int, order: EventRecordsOrder = createdAt_DESC, skip: Int, take: Int): [EventRecord]
@@ -550,6 +557,9 @@ type Query {
   publicJsonFile(name: String!): PublicJsonFile!
   tour(id: ID!): Tour!
   tours(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
+  wasteAddresses(ids: [ID], limit: Int, order: WasteLocationOrder = createdAt_DESC, skip: Int): [Address!]!
+  wasteLocationType(id: ID!): WasteLocationType!
+  wasteLocationTypes: [WasteLocationType!]!
   weatherMap(id: ID): OpenWeatherMap!
   weatherMaps(ids: [ID], limit: Int, order: OpenWeatherMapsOrder = createdAt_DESC, skip: Int): [OpenWeatherMap]
 }
@@ -618,6 +628,41 @@ enum ToursOrder {
   name_DESC
   updatedAt_ASC
   updatedAt_DESC
+}
+
+enum WasteLocationOrder {
+  createdAt_ASC
+  createdAt_DESC
+  id_ASC
+  id_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+}
+
+type WasteLocationType {
+  address: Address
+  addressId: Int
+  createdAt: String
+  id: ID
+  listPickUpDates: [String!]
+  pickUpTimes: [WastePickUpTime!]
+  updatedAt: String
+  wasteType: String
+}
+
+input WasteLocationTypeInput {
+  address: AddressInput
+  addressId: Int
+  wasteType: String
+}
+
+type WastePickUpTime {
+  createdAt: String
+  id: ID
+  pickupDate: String
+  updatedAt: String
+  wasteLocationType: WasteLocationType
+  wasteLocationTypeId: ID
 }
 
 type WebUrl {

--- a/schema.json
+++ b/schema.json
@@ -61,6 +61,24 @@
               "deprecationReason": null
             },
             {
+              "name": "categoryTree",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "directus",
               "description": null,
               "args": [
@@ -961,6 +979,132 @@
               "deprecationReason": null
             },
             {
+              "name": "wasteAddresses",
+              "description": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "order",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "WasteLocationOrder",
+                    "ofType": null
+                  },
+                  "defaultValue": "createdAt_DESC"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Address",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationType",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WasteLocationType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationTypes",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "WasteLocationType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "weatherMap",
               "description": null,
               "args": [
@@ -1769,6 +1913,28 @@
               "deprecationReason": null
             },
             {
+              "name": "wasteLocationTypes",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WasteLocationType",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "zip",
               "description": null,
               "args": [
@@ -1849,6 +2015,254 @@
           "kind": "SCALAR",
           "name": "Float",
           "description": "Represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WasteLocationType",
+          "description": null,
+          "fields": [
+            {
+              "name": "address",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Address",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "addressId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listPickUpDates",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pickUpTimes",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WastePickUpTime",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteType",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WastePickUpTime",
+          "description": null,
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pickupDate",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationType",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "WasteLocationType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wasteLocationTypeId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -2073,16 +2487,6 @@
           "interfaces": [
 
           ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": "Represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -4975,6 +5379,20 @@
               "deprecationReason": null
             },
             {
+              "name": "pushNotificationsSentAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "settings",
               "description": null,
               "args": [
@@ -5228,6 +5646,18 @@
               "deprecationReason": null
             },
             {
+              "name": "publicationDate_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicationDate_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "publishedAt_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5438,18 +5868,6 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updatedAt_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5457,6 +5875,18 @@
             },
             {
               "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5485,13 +5915,13 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
+              "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_DESC",
+              "name": "id_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5509,19 +5939,19 @@
               "deprecationReason": null
             },
             {
-              "name": "id_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5550,13 +5980,25 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
+              "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_DESC",
+              "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listDate_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listDate_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5574,25 +6016,13 @@
               "deprecationReason": null
             },
             {
-              "name": "id_ASC",
+              "name": "updatedAt_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "id_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "listDate_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "listDate_ASC",
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5621,13 +6051,13 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
+              "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_DESC",
+              "name": "id_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5645,13 +6075,13 @@
               "deprecationReason": null
             },
             {
-              "name": "id_ASC",
+              "name": "updatedAt_ASC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "id_DESC",
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5662,6 +6092,71 @@
         {
           "kind": "ENUM",
           "name": "ToursOrder",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "createdAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "WasteLocationOrder",
           "description": null,
           "fields": null,
           "inputFields": null,
@@ -5692,18 +6187,6 @@
               "deprecationReason": null
             },
             {
-              "name": "name_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "name_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5711,12 +6194,6 @@
             },
             {
               "name": "id_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "RAND",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -5835,18 +6312,6 @@
               "deprecationReason": null
             },
             {
-              "name": "updatedAt_ASC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updatedAt_DESC",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id_ASC",
               "description": null,
               "isDeprecated": false,
@@ -5854,6 +6319,18 @@
             },
             {
               "name": "id_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -6267,6 +6744,16 @@
               "name": "createGenericItem",
               "description": null,
               "args": [
+                {
+                  "name": "forceCreate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "pushNotification",
                   "description": null,
@@ -7352,6 +7839,57 @@
               "deprecationReason": null
             },
             {
+              "name": "createWastePickUpTime",
+              "description": null,
+              "args": [
+                {
+                  "name": "pickupDate",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "wasteLocationTypeId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "wasteLocationType",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WasteLocationTypeInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WastePickUpTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "destroyRecord",
               "description": null,
               "args": [
@@ -7799,6 +8337,16 @@
           "description": null,
           "fields": null,
           "inputFields": [
+            {
+              "name": "forceCreate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
             {
               "name": "pushNotification",
               "description": null,
@@ -8867,6 +9415,47 @@
           "interfaces": [
 
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "WasteLocationTypeInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "wasteType",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addressId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "address",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddressInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },


### PR DESCRIPTION
- there were some missing class nestings after refactoring, which will not break the rails server to run, but can be found out when building the schemas with `rake graphql:schema:dump`
- following error came up for example:
  - NameError: uninitialized constant Types::QueryTypes::WasteLocationTypeType::AddressType
  - NameError: uninitialized constant Types::AddressType