### PR TITLE
feat(static contents): handle json errors

### DIFF
--- a/app/views/static_contents/_form.html.erb
+++ b/app/views/static_contents/_form.html.erb
@@ -27,7 +27,20 @@
 
   <div class="form-group">
     <%= form.label :content %>
-    <div id="code_editor" style="height: 400px;"></div>
+    <% if static_content.data_type == "json" %>
+      <% content = static_content.content.to_s.html_safe %>
+      <% valid_json_content = JSON.parse(content) rescue nil %>
+      <% if valid_json_content %>
+        <div id="code_editor" style="height: 400px;"></div>
+      <% else %>
+        <div>
+          <p class="text-danger"><small><em>JSON format is not valid!</em></small></p>
+          <%= form.text_area :content, class: "form-control", style: "height: 400px;" %>
+        </div>
+      <% end %>
+    <% else %>
+      <div id="code_editor" style="height: 400px;"></div>
+    <% end %>
   </div>
 
   <div class="form-group">
@@ -38,34 +51,38 @@
 
 <script>
   $(function () {
-    var container = document.getElementById("code_editor")
-    var options = {
-      statusBar: false,
-      mainMenuBar: false,
-      mode: 'code',
-      <% if static_content.data_type == "json" %>
-        mainMenuBar: true,
-        modes: ['code', 'tree'],
-      <% end %>
-      onChangeText: function(jsonString) {
-        $("#static_content_content").val(jsonString);
-      }
-    }
-    var editor = new JSONEditor(container, options)
+    var container = document.getElementById("code_editor");
 
-    <% content = static_content.content.to_s.html_safe %>
-    <% if static_content.data_type == "json" %>
-      <% if content.present? %>
-        editor.set(<%= content %>);
+    if (container) {
+      var options = {
+        statusBar: false,
+        mainMenuBar: false,
+        mode: 'code',
+        <% if static_content.data_type == "json" %>
+          mainMenuBar: true,
+          modes: ['code', 'tree'],
+        <% end %>
+        onChangeText: function(jsonString) {
+          $("#static_content_content").val(jsonString);
+        }
+      };
+      var editor = new JSONEditor(container, options);
+
+      <% content = static_content.content.to_s.html_safe %>
+      <% if static_content.data_type == "json" %>
+        <% valid_json_content = JSON.parse(content) rescue nil %>
+        <% if content.present? && valid_json_content %>
+          editor.set(<%= content %>);
+        <% else %>
+          editor.set({});
+        <% end %>
       <% else %>
-        editor.set({});
+        <% if content.present? %>
+          editor.setText("<%= escape_javascript(content) %>");
+        <% else %>
+          editor.setText("");
+        <% end %>
       <% end %>
-    <% else %>
-      <% if content.present? %>
-        editor.setText("<%= escape_javascript(content) %>");
-      <% else %>
-        editor.setText("");
-      <% end %>
-    <% end %>
+    }
   });
 </script>

--- a/app/views/static_contents/show.html.erb
+++ b/app/views/static_contents/show.html.erb
@@ -9,7 +9,20 @@
 
     <div class="form-group">
       <label>Content</label>
-      <div id="code_editor" style="height: 400px;"></div>
+      <% if @static_content.data_type == "json" %>
+        <% content = @static_content.content.to_s.html_safe %>
+        <% valid_json_content = JSON.parse(content) rescue nil %>
+        <% if valid_json_content %>
+          <div id="code_editor" style="height: 400px;"></div>
+        <% else %>
+          <div>
+            <p class="text-danger"><small><em>JSON format is not valid!</em></small></p>
+            <pre><%= content %></pre>
+          </div>
+        <% end %>
+      <% else %>
+        <div id="code_editor" style="height: 400px;"></div>
+      <% end %>
     </div>
 
     <div class="form-group">
@@ -21,38 +34,42 @@
 
 <script>
   $(function () {
-    var container = document.getElementById("code_editor")
-    var options = {
-      statusBar: false,
-      mainMenuBar: false,
-      mode: 'code',
-      <% if @static_content.data_type == "json" %>
-        mainMenuBar: true,
-        modes: ['code', 'view'],
-      <% end %>
-      onEditable: function (node) {
-        if (!node.path) {
-          // In modes code and text, node is empty: no path, field, or value
-          // returning false makes the text area read-only
-          return false;
-        }
-      },
-    }
-    var editor = new JSONEditor(container, options)
+    var container = document.getElementById("code_editor");
 
-    <% content = @static_content.content.to_s.html_safe %>
-    <% if @static_content.data_type == "json" %>
-      <% if content.present? %>
-        editor.set(<%= content %>);
+    if (container) {
+      var options = {
+        statusBar: false,
+        mainMenuBar: false,
+        mode: 'code',
+        <% if @static_content.data_type == "json" %>
+          mainMenuBar: true,
+          modes: ['code', 'view'],
+        <% end %>
+        onEditable: function (node) {
+          if (!node.path) {
+            // In modes code and text, node is empty: no path, field, or value
+            // returning false makes the text area read-only
+            return false;
+          }
+        },
+      };
+      var editor = new JSONEditor(container, options);
+
+      <% content = @static_content.content.to_s.html_safe %>
+      <% if @static_content.data_type == "json" %>
+        <% valid_json_content = JSON.parse(content) rescue nil %>
+        <% if content.present? && valid_json_content %>
+          editor.set(<%= content %>);
+        <% else %>
+          editor.set({});
+        <% end %>
       <% else %>
-        editor.set({});
+        <% if content.present? %>
+          editor.setText("<%= escape_javascript(content) %>");
+        <% else %>
+          editor.setText("");
+        <% end %>
       <% end %>
-    <% else %>
-      <% if content.present? %>
-        editor.setText("<%= escape_javascript(content) %>");
-      <% else %>
-        editor.setText("");
-      <% end %>
-    <% end %>
+    }
   });
 </script>


### PR DESCRIPTION
- added json parsing to check if content is valid
- added checks for triggering json editor javascript only if the container with the id is present
- added fallback rendering if json is not valid to show content anyways in show view
- added fallback text area if json is not valid to be able to edit the content anyways in edit view

|render content if error with json|edit text area to edit json with error|show editor for fixed json|
|----|----|----|
|![Bildschirmfoto 2021-03-29 um 19 13 09](https://user-images.githubusercontent.com/1942953/112874776-a10df100-90c3-11eb-85ce-045d18a99f53.png)|![Bildschirmfoto 2021-03-29 um 19 13 14](https://user-images.githubusercontent.com/1942953/112874794-a703d200-90c3-11eb-9c62-2f350b363683.png)|![Bildschirmfoto 2021-03-29 um 19 13 22](https://user-images.githubusercontent.com/1942953/112874818-abc88600-90c3-11eb-98d2-b42a3a480f3f.png)|

SVA-133