### PR TITLE
Extend store time to 96 hours

### DIFF
--- a/app/controllers/notification/devices_controller.rb
+++ b/app/controllers/notification/devices_controller.rb
@@ -39,7 +39,7 @@ class Notification::DevicesController < ApplicationController
   # GET /notification/devices/1
   # GET /notification/devices/1.json
   def show
-    @push_logs = RedisAdapter.get_push_log_for_device(@notification_device.token)
+    @push_logs = RedisAdapter.get_push_logs_for_device(@notification_device.token)
   end
 
   # GET /notification/devices/new
@@ -49,7 +49,7 @@ class Notification::DevicesController < ApplicationController
 
   # GET /notification/devices/1/edit
   def edit
-    @push_logs = RedisAdapter.get_push_log_for_device(@notification_device.token)
+    @push_logs = RedisAdapter.get_push_logs_for_device(@notification_device.token)
   end
 
   # POST /notification/devices

--- a/app/services/redis_adapter.rb
+++ b/app/services/redis_adapter.rb
@@ -11,12 +11,13 @@ module RedisAdapter
     #
     def add_push_log(device_token, message)
       redis.rpush("#{namespace}:push_log:#{device_token}", message.to_json)
-      redis.expire("#{namespace}:push_log:#{device_token}", 24.hours.to_i)
+      redis.expire("#{namespace}:push_log:#{device_token}", 96.hours.to_i)
     rescue
       nil
     end
 
-    def get_push_log_for_device(device_token)
+    # Load list of Push Logs for a single device
+    def get_push_logs_for_device(device_token)
       redis.lrange("#{namespace}:push_log:#{device_token}", 0, -1)
     rescue
       []


### PR DESCRIPTION
Rename method to better represent storage as a list.
Extend time to life to 96 hours in Redis.