### PR TITLE
Visible-Scope zu relevanten DatatResources hinzugefügt und im Category Counter verwendet

### DIFF
--- a/app/graphql/types/query_types/category_type.rb
+++ b/app/graphql/types/query_types/category_type.rb
@@ -4,6 +4,7 @@ module Types
   class QueryTypes::CategoryType < Types::BaseObject
     field :id, ID, null: true
     field :name, String, null: true
+    field :generic_items_count, Integer, null: true
     field :points_of_interest_count, Integer, null: true
     field :tours_count, Integer, null: true
     field :news_items_count, Integer, null: true

--- a/app/models/data_resources/attraction.rb
+++ b/app/models/data_resources/attraction.rb
@@ -21,6 +21,8 @@ class Attraction < ApplicationRecord
   has_many :web_urls, as: :web_urlable, dependent: :destroy
   has_one :external_reference, as: :external, dependent: :destroy
 
+  scope :visible, -> { where(visible: true) }
+
   validates_presence_of :name
   acts_as_taggable
 

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -30,6 +30,8 @@ class EventRecord < ApplicationRecord
   has_many :dates, as: :dateable, class_name: "FixedDate", dependent: :destroy
   has_one :external_reference, as: :external, dependent: :destroy
 
+  scope :visible, -> { where(visible: true) }
+
   # timespan_to_search und timespan werden Arrays der Eventzeiträume
   # und deren Schnittemenge > 0 bedeutet eine Überschneidung.
   #

--- a/app/models/data_resources/generic_item.rb
+++ b/app/models/data_resources/generic_item.rb
@@ -27,6 +27,7 @@ class GenericItem < ApplicationRecord
   has_many :price_informations, as: :priceable, class_name: "Price", dependent: :destroy
   has_many :web_urls, as: :web_urlable, dependent: :destroy
 
+  scope :visible, -> { where(visible: true) }
   scope :with_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)
   }

--- a/app/models/data_resources/news_item.rb
+++ b/app/models/data_resources/news_item.rb
@@ -25,6 +25,7 @@ class NewsItem < ApplicationRecord
   scope :with_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)
   }
+  scope :visible, -> { where(visible: true) }
 
   accepts_nested_attributes_for :content_blocks, :data_provider, :address, :source_url
 

--- a/app/models/data_resources/resource_modules/category.rb
+++ b/app/models/data_resources/resource_modules/category.rb
@@ -11,31 +11,38 @@ class Category < ApplicationRecord
   has_many :points_of_interest, source: :data_resource, source_type: "PointOfInterest", through: :data_resource_categories
   has_many :tours, source: :data_resource, source_type: "Tour", through: :data_resource_categories
   has_many :news_items, source: :data_resource, source_type: "NewsItem", through: :data_resource_categories
+  has_many :generic_items, source: :data_resource, source_type: "GenericItem", through: :data_resource_categories
 
   after_destroy :cleanup_data_resource_settings
+
+  def generic_items_count
+    return 0 if generic_items.blank?
+
+    generic_items.visible.count
+  end
 
   def points_of_interest_count
     return 0 if points_of_interest.blank?
 
-    points_of_interest.count
+    points_of_interest.visible.count
   end
 
   def tours_count
     return 0 if tours.blank?
 
-    tours.count
+    tours.visible.count
   end
 
   def news_items_count
     return 0 if news_items.blank?
 
-    news_items.count
+    news_items.visible.count
   end
 
   def event_records_count
     return 0 if event_records.blank?
 
-    event_records.count
+    event_records.visible.count
   end
 
   def upcoming_event_records


### PR DESCRIPTION
Scope :visible hinzugefügt zu:

- Attraction (Tour/POI)
- EventRecord
- NewsItem
- GenericItem


Alle DataResource Counter zählen nun nur noch die sichtbaren Elemente.
Zusätzlich wurde der Vollständigkeit halber ein Counter für GenericItem hinzugefügt
