### PR TITLE
Skip recreation of similar records if invisible

### DIFF
--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -54,7 +54,7 @@ class ResourceService
     return @resource.compareable_attributes == record.compareable_attributes if record.respond_to?(:compareable_attributes)
 
     # Fallback, wenn :compareable_attributes nicht beim Model definiert ist.
-    except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id"]
+    except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id", "visible"]
     @resource.attributes.except(*except_attributes) == record.attributes.except(*except_attributes)
   end
 


### PR DESCRIPTION
If a Record is marked as "not visible", the duplication recognition valid and would have generated a new record.

Last seen as TMB-Imports of "Apotheken"