### PR TITLE
refactor(DirectusLoader): restructure and add standard error

### DIFF
--- a/app/graphql/loaders/directus_loader.rb
+++ b/app/graphql/loaders/directus_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "graphql/remote_loader"
 
 # The gem handles most of the heavy lifting, but it's left up to the application
@@ -11,7 +13,6 @@ require "graphql/remote_loader"
 # The returned value should be a hash or a type that responds to #to_h.
 #
 # This loader uses GraphQL::Client to query the remote API.
-# DirectusClient is defined in config/application.rb
 class DirectusLoader < GraphQL::RemoteLoader::Loader
   def query(query_string, context: {})
     return unless directus_defined?
@@ -21,27 +22,22 @@ class DirectusLoader < GraphQL::RemoteLoader::Loader
     directus_client.query(parsed_query, variables: {}, context: {})
   end
 
-  def directus_defined?
-    Rails.application.credentials.dig(:directus, :graphql_endpoint).present?
-  end
-
   # EXAMPLE FROM https://github.com/d12/graphql-remote_loader_example/blob/master/config/application.rb
   #
-  # Defining the GraphQL::Client HTTP adapter and client that we use in query method
+  # Defining the GraphQL::Client that we use in query method
   def directus_client
-    begin
-      @directus_client ||= GraphQL::Client.new(
-        schema: GraphQL::Client.load_schema(directus_http_adapter),
-        execute: directus_http_adapter
-      )
-      @directus_client.allow_dynamic_queries = true
+    @directus_client ||= GraphQL::Client.new(
+      schema: GraphQL::Client.load_schema(directus_http_adapter),
+      execute: directus_http_adapter
+    )
+    @directus_client.allow_dynamic_queries = true
 
-      return @directus_client
-    rescue
-      nil
-    end
+    @directus_client
+  rescue StandardError
+    nil
   end
 
+  # Defining the GraphQL::Client::HTTP adapter that we use in query method
   def directus_http_adapter
     graphql_endpoint = Rails.application.credentials.dig(:directus, :graphql_endpoint)
     return if graphql_endpoint.blank?
@@ -55,4 +51,7 @@ class DirectusLoader < GraphQL::RemoteLoader::Loader
     end
   end
 
+  def directus_defined?
+    Rails.application.credentials.dig(:directus, :graphql_endpoint).present?
+  end
 end


### PR DESCRIPTION
- added `StandardError` to rescue, because:
  > Style/RescueStandardError: Avoid rescuing without specifying an error class.
- updated comments

SVA-219