### PR TITLE
feat(surveys): allow deletion of `Survey::Poll`s

### DIFF
--- a/app/graphql/mutations/destroy_record.rb
+++ b/app/graphql/mutations/destroy_record.rb
@@ -47,6 +47,11 @@ module Mutations
       def destroy_record(record)
         if record.present?
           record.destroy
+
+          if record.errors.present?
+            return { status: record.errors.full_messages.join(", "), status_code: 500 }
+          end
+
           { status: "Record destroyed", status_code: 200 }
         else
           { status: "Record not found", status_code: 404 }

--- a/app/graphql/mutations/destroy_record.rb
+++ b/app/graphql/mutations/destroy_record.rb
@@ -8,7 +8,14 @@ module Mutations
 
     type Types::DestroyType
 
-    RECORD_WHITELIST = ["EventRecord", "NewsItem", "PointOfInterest", "Tour", "GenericItem"].freeze
+    RECORD_WHITELIST = [
+      "EventRecord",
+      "NewsItem",
+      "PointOfInterest",
+      "Tour",
+      "GenericItem",
+      "Survey::Poll"
+    ].freeze
 
     def resolve(id: nil, record_type:, external_id: nil)
       return error_status unless RECORD_WHITELIST.include?(record_type)

--- a/app/graphql/mutations/destroy_record.rb
+++ b/app/graphql/mutations/destroy_record.rb
@@ -48,11 +48,11 @@ module Mutations
         if record.present?
           record.destroy
 
-          if record.errors.present?
-            return { status: record.errors.full_messages.join(", "), status_code: 500 }
+          if record.destroyed?
+            { status: "Record destroyed", status_code: 200 }
+          else
+            { status: record.errors.full_messages.join(", "), status_code: 500 }
           end
-
-          { status: "Record destroyed", status_code: 200 }
         else
           { status: "Record not found", status_code: 404 }
         end

--- a/app/models/survey/poll.rb
+++ b/app/models/survey/poll.rb
@@ -4,7 +4,7 @@ class Survey::Poll < ApplicationRecord
   include FilterByRole
 
   has_one :date, as: :dateable, class_name: "FixedDate", dependent: :destroy
-  has_many :questions, class_name: "Survey::Question", foreign_key: "survey_poll_id", dependent: :restrict_with_error
+  has_many :questions, class_name: "Survey::Question", foreign_key: "survey_poll_id", dependent: :destroy
 
   belongs_to :data_provider
 

--- a/app/models/survey/question.rb
+++ b/app/models/survey/question.rb
@@ -2,7 +2,7 @@
 
 class Survey::Question < ApplicationRecord
   belongs_to :poll, class_name: "Survey::Poll", optional: true, foreign_key: "survey_poll_id"
-  has_many :response_options, class_name: "Survey::ResponseOption", foreign_key: "survey_question_id", dependent: :restrict_with_error
+  has_many :response_options, class_name: "Survey::ResponseOption", foreign_key: "survey_question_id", dependent: :destroy
 
   store :title, coder: JSON
 end

--- a/app/models/survey/response_option.rb
+++ b/app/models/survey/response_option.rb
@@ -4,16 +4,6 @@ class Survey::ResponseOption < ApplicationRecord
   belongs_to :question, class_name: "Survey::Question", optional: true, foreign_key: "survey_question_id"
 
   store :title, coder: JSON
-
-  before_destroy :any_votes_present?, prepend: true do
-    throw(:abort) if errors.present?
-  end
-
-  private
-
-    def any_votes_present?
-      errors.add(:votes_count, "Cannot delete ResponseOption with votes") if votes_count.positive?
-    end
 end
 
 # == Schema Information

--- a/spec/factories/survey.rb
+++ b/spec/factories/survey.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :survey, class: "Survey::Poll" do
+    title { { de: "Umfrage" }.to_json }
+    description { { de: "Beschreibung" }.to_json }
+    visible { true }
+    data_provider_id { create(:data_provider).id }
+  end
+end

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable RSpec/FilePath
+# not only poll is checked here but every child model as well so we keep the file named survey_spec
+RSpec.describe Survey::Poll, type: :model do
+  describe "#destroy" do
+    before do
+      @survey = create(:survey)
+      @question = @survey.questions.create
+      @response_option = @question.response_options.create
+    end
+
+    context "with a vote_count" do
+      before do
+        @response_option.update(votes_count: 2)
+      end
+
+      it "is possible to delete poll, question and answer_options in one step" do
+        result = @survey.destroy
+        expect(result.destroyed?).to be true
+        expect(@question.destroyed?).to be true
+        expect(@response_option.destroyed?).to be true
+      end
+
+      it "is possible to delete a single answer_option" do
+        result = @response_option.destroy
+        expect(result.destroyed?).to be true
+      end
+    end
+
+    context "without a vote_count" do
+      it "is possible to delete poll, question and answer_options in one step" do
+        result = @survey.destroy
+        expect(result.destroyed?).to be true
+        expect(@question.destroyed?).to be true
+        expect(@response_option.destroyed?).to be true
+      end
+
+      it "is possible to delete a single answer_option" do
+        result = @response_option.destroy
+        expect(result.destroyed?).to be true
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath


### PR DESCRIPTION
c4eb661 feat(surveys): allow deletion of `Survey::Poll`s
61827ae feat(surveys): add return case if records cannot be deleted because of errors
ed89475 feat(surveys): add :destroy for dependencies of `Survey::Poll`
1458bd3 feat(surveys): remove before_destroy checking votes

SVA2-6

- everything should be destroyed if a survey deletion is triggered
  > Wenn ich eine Umfrage lösche, löschen sich alle zugehörigen Antworten, Stimmen und Kommentare automatisch mit
- on the other hand, the logic did not work properly while testing the `before_destroy` check

<img width="1024" alt="Bildschirmfoto 2021-06-17 um 17 43 01" src="https://user-images.githubusercontent.com/1942953/122435140-07563180-cf98-11eb-8e33-710bc39b78bc.png">