### PR TITLE
Admin Account ohne OAuto Application

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -12,12 +12,16 @@ class Users::SessionsController < Devise::SessionsController
     sign_in(resource_name, resource)
     resource.save # recreates authentication_token after sign in
 
-    graphql_access_token = Doorkeeper::AccessToken.create(
-      application: resource.oauth_applications.first,
-      resource_owner_id: resource.id,
-      expires_in: 1.day
-    ).token
-    cookies["_graphql_token"] = graphql_access_token
+    # Ein Login zum Graphiql Interface ist nur mit einer
+    # OAuth-Application möglich.
+    if resource.oauth_applications.any?
+      graphql_access_token = Doorkeeper::AccessToken.create(
+        application: resource.oauth_applications.first,
+        resource_owner_id: resource.id,
+        expires_in: 1.day
+      ).token
+      cookies["_graphql_token"] = graphql_access_token
+    end
 
     respond_to do |format|
       format.html { respond_with resource, location: after_sign_in_path_for(resource) }

--- a/app/services/api_request_service.rb
+++ b/app/services/api_request_service.rb
@@ -21,6 +21,8 @@ class ApiRequestService
   end
 
   def get_request(content_type_xml=false)
+    return nil if @uri.blank?
+
     uri = Addressable::URI.parse(@uri.strip).normalize
 
     uri.query = [uri.query, URI.encode_www_form(@params)].join("&") if @params && @params.any?


### PR DESCRIPTION
Der Login schlägt fehl wenn der Account keine OAuth-Application besitzt.
Diese wird normalerweise beim anlegen des Accounts erzeugt, aber wenn diese Manuell gelöscht wird oder zu Test/Dev-Zwecken nicht vorhanden ist, schlägt hier der Login fehl.

Daher wird nun vorab geprüft, ob es mindestens eine OAuth-App für den anzumeldenden User gibt.