### PR TITLE
Survey Comments

### DIFF
--- a/app/graphql/mutations/change_visibility.rb
+++ b/app/graphql/mutations/change_visibility.rb
@@ -8,7 +8,7 @@ module Mutations
 
     type Types::StatusType
 
-    RECORD_WHITELIST = ["EventRecord", "NewsItem", "PointOfInterest", "Tour", "Survey::Poll"].freeze
+    RECORD_WHITELIST = ["EventRecord", "NewsItem", "PointOfInterest", "Tour", "Survey::Poll", "Survey::Comment"].freeze
 
     def resolve(id:, record_type:, visible:)
       return error_status("recordType") unless RECORD_WHITELIST.include?(record_type)

--- a/app/graphql/mutations/change_visibility.rb
+++ b/app/graphql/mutations/change_visibility.rb
@@ -8,13 +8,21 @@ module Mutations
 
     type Types::StatusType
 
-    RECORD_WHITELIST = ["EventRecord", "NewsItem", "PointOfInterest", "Tour", "Survey::Poll", "Survey::Comment"].freeze
+    RECORD_WHITELIST = [
+      "EventRecord",
+      "NewsItem",
+      "PointOfInterest",
+      "Tour",
+      "Survey::Poll",
+      "Survey::Comment"
+    ].freeze
 
     def resolve(id:, record_type:, visible:)
       return error_status("recordType") unless RECORD_WHITELIST.include?(record_type)
       return error_status("visible") unless [true, false].include?(visible)
 
-      record = record_type.constantize
+      record = record_type
+                 .constantize
                  .filtered_for_current_user(context[:current_user])
                  .where(id: id)
                  .first

--- a/app/graphql/mutations/comment_survey.rb
+++ b/app/graphql/mutations/comment_survey.rb
@@ -20,7 +20,7 @@ module Mutations
         comment.save
         OpenStruct.new(id: survey_id, status: "comment successfully", status_code: 200)
       rescue => e
-        error_status("Error on commenting: #{e}")
+        error_status("Error on commenting: #{e}", 500)
       end
     end
 

--- a/app/graphql/mutations/comment_survey.rb
+++ b/app/graphql/mutations/comment_survey.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: false
+
+module Mutations
+  class CommentSurvey < BaseMutation
+    argument :survey_id, ID, required: true
+    argument :message, String, required: true
+
+    type Types::StatusType
+
+    def resolve(survey_id:, message:)
+      survey = Survey::Poll.find_by(id: survey_id)
+
+      return error_status("Access not permitted: Survey missing") if survey.blank?
+      return error_status("Access not permitted: Survey already archived") if survey.archived?
+
+      comment = survey.comments.build(message: message)
+      return error_status("Access not permitted: Comment invalid, #{comment.error_messages}") unless comment.valid?
+
+      begin
+        comment.save
+        OpenStruct.new(id: survey_id, status: "comment successfully", status_code: 200)
+      rescue => e
+        error_status("Error on commenting: #{e}")
+      end
+    end
+
+    private
+
+      def error_status(description, status_code = 403)
+        OpenStruct.new(id: nil, status: description, status_code: status_code)
+      end
+  end
+end

--- a/app/graphql/mutations/comment_survey.rb
+++ b/app/graphql/mutations/comment_survey.rb
@@ -18,7 +18,7 @@ module Mutations
 
       begin
         comment.save
-        OpenStruct.new(id: survey_id, status: "comment successfully", status_code: 200)
+        OpenStruct.new(id: comment.id, status: "commented survey #{survey_id} successfully", status_code: 200)
       rescue => e
         error_status("Error on commenting: #{e}", 500)
       end

--- a/app/graphql/mutations/vote_for_survey.rb
+++ b/app/graphql/mutations/vote_for_survey.rb
@@ -20,7 +20,7 @@ module Mutations
 
         OpenStruct.new(id: nil, status: "voted successfully, increased: #{increase_id} decreased: #{decrease_id}", status_code: 200)
       rescue => e
-        error_status("Error on voting: #{e}")
+        error_status("Error on voting: #{e}", 500)
       end
     end
 

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -18,5 +18,6 @@ module Types
     # actions
     field :change_visibility, mutation: Mutations::ChangeVisibility
     field :vote_for_survey, mutation: Mutations::VoteForSurvey
+    field :comment_survey, mutation: Mutations::CommentSurvey
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -55,6 +55,10 @@ module Types
       argument :category_id, ID, required: false
     end
 
+    field :survey_comments, [QueryTypes::SurveyComment], null: false do
+      argument :survey_id, ID, required: false
+    end
+
     field :lunches, [QueryTypes::LunchType], function: Resolvers::LunchesSearch
     field :lunch, QueryTypes::LunchType, null: false do
       argument :id, ID, required: true
@@ -69,6 +73,14 @@ module Types
       return latest_weather_map if latest_weather_map.present? && latest_weather_map.created_at > (Time.now - 1.hour)
 
       WeatherMapService.new.import
+    end
+
+    def survey_comments(survey_id: nil)
+      comments = Survey::Comment.filtered_for_current_user(context[:current_user])
+
+      return comments.where(survey_poll_id: survey_id) if survey_id.present?
+
+      comments
     end
 
     def point_of_interest(id:)

--- a/app/graphql/types/query_types/survey_comment.rb
+++ b/app/graphql/types/query_types/survey_comment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class QueryTypes::SurveyComment < Types::BaseObject
+    field :id, ID, null: true
+    field :survey_poll_id, ID, null: true
+    field :message, String, null: true
+    field :amount, Float, null: true
+    field :visible, Boolean, null: true
+  end
+end

--- a/app/graphql/types/query_types/survey_comment.rb
+++ b/app/graphql/types/query_types/survey_comment.rb
@@ -5,7 +5,7 @@ module Types
     field :id, ID, null: true
     field :survey_poll_id, ID, null: true
     field :message, String, null: true
-    field :amount, Float, null: true
     field :visible, Boolean, null: true
+    field :created_at, String, null: true
   end
 end

--- a/app/graphql/types/query_types/survey_poll_type.rb
+++ b/app/graphql/types/query_types/survey_poll_type.rb
@@ -3,6 +3,7 @@
 module Types
   class QueryTypes::SurveyPollType < Types::BaseObject
     field :id, ID, null: true
+    field :survey_comments, [QueryTypes::SurveyComment], null: true
     field :title, QueryTypes::I18nJSON, null: true
     field :question_id, ID, null: true
     field :question_title, QueryTypes::I18nJSON, null: true
@@ -13,5 +14,9 @@ module Types
     field :visible, Boolean, null: true
     field :updated_at, String, null: true
     field :created_at, String, null: true
+
+    def survey_comments
+      object.comments.filtered_for_current_user(context[:current_user])
+    end
   end
 end

--- a/app/models/survey/comment.rb
+++ b/app/models/survey/comment.rb
@@ -1,0 +1,17 @@
+class Survey::Comment < ApplicationRecord
+  belongs_to :poll, class_name: "Survey::Poll", optional: true, foreign_key: "survey_poll_id"
+
+  scope :visible, -> { where(visible: true) }
+  scope :invisible, -> { where(visible: false) }
+  scope :filtered_for_current_user, lambda { |current_user|
+    return all if current_user.admin_role?
+    return visible if current_user.app_role?
+
+    if current_user.editor_role?
+      data_provider_ids = [current_user.data_provider_id] + User.restricted_role.map(&:data_provider_id)
+      return includes(:poll).where(poll: { data_provider_id: data_provider_ids.compact.flatten })
+    end
+
+    includes(:poll).where(survey_polls: { data_provider_id: current_user.data_provider_id })
+  }
+end

--- a/app/models/survey/comment.rb
+++ b/app/models/survey/comment.rb
@@ -1,15 +1,18 @@
+# frozen_string_literal: true
+
 class Survey::Comment < ApplicationRecord
+  include FilterByRole
+
   belongs_to :poll, class_name: "Survey::Poll", optional: true, foreign_key: "survey_poll_id"
 
-  scope :visible, -> { where(visible: true) }
-  scope :invisible, -> { where(visible: false) }
+  # NOTE: this scope from `FilterByRole` needs to be overridden with adding `includes` for `poll`s
   scope :filtered_for_current_user, lambda { |current_user|
     return all if current_user.admin_role?
     return visible if current_user.app_role?
 
     if current_user.editor_role?
       data_provider_ids = [current_user.data_provider_id] + User.restricted_role.map(&:data_provider_id)
-      return includes(:poll).where(poll: { data_provider_id: data_provider_ids.compact.flatten })
+      return includes(:poll).where(survey_polls: { data_provider_id: data_provider_ids.compact.flatten })
     end
 
     includes(:poll).where(survey_polls: { data_provider_id: current_user.data_provider_id })

--- a/app/models/survey/poll.rb
+++ b/app/models/survey/poll.rb
@@ -7,6 +7,7 @@ class Survey::Poll < ApplicationRecord
 
   has_one :date, as: :dateable, class_name: "FixedDate", dependent: :destroy
   has_many :questions, class_name: "Survey::Question", foreign_key: "survey_poll_id", dependent: :destroy
+  has_many :comments, class_name: "Survey::Comment", foreign_key: "survey_poll_id", dependent: :destroy
 
   belongs_to :data_provider
 
@@ -37,6 +38,13 @@ class Survey::Poll < ApplicationRecord
 
   def question_title
     questions.try(:first).try(:title)
+  end
+
+  def archived?
+    return false if date.blank?
+    return false if date.date_end.blank?
+
+    date.date_end < Date.today
   end
 
   def response_options

--- a/db/migrate/20210702072005_create_survey_comments.rb
+++ b/db/migrate/20210702072005_create_survey_comments.rb
@@ -1,0 +1,11 @@
+class CreateSurveyComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :survey_comments do |t|
+      t.integer :survey_poll_id
+      t.text :message
+      t.boolean :visible, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_064433) do
+ActiveRecord::Schema.define(version: 2021_07_02_072005) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -423,6 +423,14 @@ ActiveRecord::Schema.define(version: 2021_06_17_064433) do
     t.string "name"
     t.string "data_type"
     t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "survey_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "survey_poll_id"
+    t.text "message"
+    t.boolean "visible", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -366,6 +366,7 @@ input MediaContentInput {
 
 type Mutation {
   changeVisibility(id: ID!, recordType: String!, visible: Boolean!): Status!
+  commentSurvey(message: String!, surveyId: ID!): Status!
   createAppUserContent(content: String, dataSource: String, dataType: String): AppUserContent!
   createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
   createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, forceCreate: Boolean, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
@@ -608,7 +609,16 @@ type Status {
   statusCode: Int
 }
 
+type SurveyComment {
+  amount: Float
+  id: ID
+  message: String
+  surveyPollId: ID
+  visible: Boolean
+}
+
 type SurveyPoll {
+  comments: [SurveyComment!]
   createdAt: String
   dataProvider: DataProvider
   date: Date

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -565,6 +565,7 @@ type Query {
   pointsOfInterest(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!
   publicJsonFile(name: String!): PublicJsonFile!
+  surveyComments(surveyId: ID): [SurveyComment!]!
   surveys(archived: Boolean, ids: [ID], ongoing: Boolean): [SurveyPoll!]!
   tour(id: ID!): Tour!
   tours(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
@@ -610,7 +611,7 @@ type Status {
 }
 
 type SurveyComment {
-  amount: Float
+  createdAt: String
   id: ID
   message: String
   surveyPollId: ID
@@ -618,7 +619,6 @@ type SurveyComment {
 }
 
 type SurveyPoll {
-  comments: [SurveyComment!]
   createdAt: String
   dataProvider: DataProvider
   date: Date
@@ -627,6 +627,7 @@ type SurveyPoll {
   questionId: ID
   questionTitle: I18nJSON
   responseOptions: [SurveyResponseOptions!]
+  surveyComments: [SurveyComment!]
   title: I18nJSON
   updatedAt: String
   visible: Boolean

--- a/public/schema.json
+++ b/public/schema.json
@@ -849,6 +849,41 @@
               "deprecationReason": null
             },
             {
+              "name": "surveyComments",
+              "description": null,
+              "args": [
+                {
+                  "name": "surveyId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SurveyComment",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "surveys",
               "description": null,
               "args": [
@@ -6365,6 +6400,89 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SurveyComment",
+          "description": null,
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surveyPollId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "visible",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "LunchesOrder",
           "description": null,
@@ -6416,28 +6534,6 @@
           "name": "SurveyPoll",
           "description": null,
           "fields": [
-            {
-              "name": "comments",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "SurveyComment",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "createdAt",
               "description": null,
@@ -6559,6 +6655,28 @@
               "deprecationReason": null
             },
             {
+              "name": "surveyComments",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SurveyComment",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "title",
               "description": null,
               "args": [
@@ -6581,89 +6699,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "visible",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "SurveyComment",
-          "description": null,
-          "fields": [
-            {
-              "name": "amount",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "surveyPollId",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/public/schema.json
+++ b/public/schema.json
@@ -6417,6 +6417,28 @@
           "description": null,
           "fields": [
             {
+              "name": "comments",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SurveyComment",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createdAt",
               "description": null,
               "args": [
@@ -6587,6 +6609,89 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SurveyComment",
+          "description": null,
+          "fields": [
+            {
+              "name": "amount",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surveyPollId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "visible",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "I18nJSON",
           "description": "      A specific JSON type representing I18n\n      text data, for example:\n      ```\n      {\n        de: \"deutscher Text\",\n        en: \"englischer Text\"\n      }\n      ```\n",
@@ -6725,6 +6830,51 @@
                     "ofType": {
                       "kind": "SCALAR",
                       "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Status",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "commentSurvey",
+              "description": null,
+              "args": [
+                {
+                  "name": "surveyId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "message",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
                       "ofType": null
                     }
                   },

--- a/schema.graphql
+++ b/schema.graphql
@@ -366,6 +366,7 @@ input MediaContentInput {
 
 type Mutation {
   changeVisibility(id: ID!, recordType: String!, visible: Boolean!): Status!
+  commentSurvey(message: String!, surveyId: ID!): Status!
   createAppUserContent(content: String, dataSource: String, dataType: String): AppUserContent!
   createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
   createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, forceCreate: Boolean, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
@@ -564,6 +565,7 @@ type Query {
   pointsOfInterest(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!
   publicJsonFile(name: String!): PublicJsonFile!
+  surveyComments(surveyId: ID): [SurveyComment!]!
   surveys(archived: Boolean, ids: [ID], ongoing: Boolean): [SurveyPoll!]!
   tour(id: ID!): Tour!
   tours(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
@@ -608,6 +610,14 @@ type Status {
   statusCode: Int
 }
 
+type SurveyComment {
+  createdAt: String
+  id: ID
+  message: String
+  surveyPollId: ID
+  visible: Boolean
+}
+
 type SurveyPoll {
   createdAt: String
   dataProvider: DataProvider
@@ -617,6 +627,7 @@ type SurveyPoll {
   questionId: ID
   questionTitle: I18nJSON
   responseOptions: [SurveyResponseOptions!]
+  surveyComments: [SurveyComment!]
   title: I18nJSON
   updatedAt: String
   visible: Boolean

--- a/schema.json
+++ b/schema.json
@@ -849,6 +849,41 @@
               "deprecationReason": null
             },
             {
+              "name": "surveyComments",
+              "description": null,
+              "args": [
+                {
+                  "name": "surveyId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SurveyComment",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "surveys",
               "description": null,
               "args": [
@@ -6365,6 +6400,89 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "SurveyComment",
+          "description": null,
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surveyPollId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "visible",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "LunchesOrder",
           "description": null,
@@ -6529,6 +6647,28 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "SurveyResponseOptions",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surveyComments",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "SurveyComment",
                     "ofType": null
                   }
                 }
@@ -6725,6 +6865,51 @@
                     "ofType": {
                       "kind": "SCALAR",
                       "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Status",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "commentSurvey",
+              "description": null,
+              "args": [
+                {
+                  "name": "surveyId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "message",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
                       "ofType": null
                     }
                   },


### PR DESCRIPTION
Models erweitert und API  erstellt um:
- Kommentar zum erstellen für die App
- Kommentare an eienr Umfrage laden
- Kommentare einzeln für eine bestimmte Umfrage laden
- Sichtbarkeit eines Kommentars ändern

Rollen und Rechte werden weiterhin wie bei den anderen Resourcen berücksichtigt. Die Rolle der Umfrage ist hierbei maßgeblich für die Rolle der zugehörigen Kommentare

SVA2-22

![Bildschirmfoto 2021-07-02 um 10 07 14](https://user-images.githubusercontent.com/90779/124268732-32b15280-db3a-11eb-8dca-a248e34ed3a5.png)
![Bildschirmfoto 2021-07-02 um 12 19 34](https://user-images.githubusercontent.com/90779/124268736-33e27f80-db3a-11eb-9b3c-a11e982ad278.png)
![Bildschirmfoto 2021-07-02 um 13 26 09](https://user-images.githubusercontent.com/90779/124268739-33e27f80-db3a-11eb-8dc6-ffbb76d21b89.png)

---

```
query { surveys (){ id questionTitle date{dateEnd} comments:surveyComments{message visible} responseOptions{title votesCount}} }

mutation { changeVisibility (id: 1, recordType: "Survey::Comment", visible: true){id, status, statusCode} }

query { surveyComments { id surveyPollId message } }
query { surveyComments (surveyId: 1){ id surveyPollId message } }

mutation { commentSurvey (surveyId: 1, message: "Dies ist ein Test"){ id status statusCode }}
```