### PR TITLE
Securing push notifications

### DIFF
--- a/app/jobs/send_single_push_notification_job.rb
+++ b/app/jobs/send_single_push_notification_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class SendSinglePushNotificationJob < ApplicationJob
+  queue_as :default
+
+  # message_options = {
+  #   title: push_title,
+  #   body: push_body,
+  #   data: {
+  #     id: id,
+  #     query_type: self.class.to_s
+  #   }
+  # }
+  #
+  # device_token = "ExponentPushToken[RkCuwM123456778g29lQb0ZK]"
+  def perform(device_token, message_options)
+    client = Exponent::Push::Client.new
+    messages = [message_options.merge(to: device_token)]
+
+    begin
+      feedback = client.send_messages(messages)
+      RedisAdapter.add_push_log(device_token, message_options.merge(date: DateTime.now, payload: feedback.try(:response).try(:body)))
+    rescue => e
+      RedisAdapter.add_push_log(device_token, message_options.merge(rescue_error: "push notification", error: e, date: DateTime.now))
+    end
+  end
+end

--- a/app/services/push_notification.rb
+++ b/app/services/push_notification.rb
@@ -14,16 +14,7 @@ class PushNotification
     @client = Exponent::Push::Client.new
     Notification::Device.all.each do |device|
       device_token = device.token
-
-      # Send PushNotification
-      messages = [message_options.merge(to: device_token)]
-
-      begin
-        feedback = @client.send_messages(messages)
-        RedisAdapter.add_push_log(device_token, message_options.merge(date: DateTime.now, payload: feedback.try(:response).try(:body)))
-      rescue => e
-        RedisAdapter.add_push_log(device_token, message_options.merge(rescue_error: "push notification", error: e, date: DateTime.now))
-      end
+      SendSinglePushNotificationJob.perform_later(device_token, message_options)
     end
   end
 end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,3 @@
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.max_attempts = 1
+Delayed::Worker.max_run_time = 8.hour


### PR DESCRIPTION
- a delayed job task can only be executed one time
- max runtime is extendet to 8 hours
- the backgroundjob of sending a push to all devises will now create
  an additional background job to send each single push notification
  => A push article to 4000 devices will now lead to 4000 delayed_job entries,
       wich will be handled one by one.