### PR TITLE
Namspacing for data resources

### DIFF
--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -61,7 +61,7 @@ module Mutations
 
     def resolve(**params)
       ResourceService.new(data_provider: context[:current_user].try(:data_provider))
-        .create(EventRecord, params)
+        .create(DataResource::EventRecord, params)
     end
   end
 end

--- a/app/graphql/mutations/create_news_item.rb
+++ b/app/graphql/mutations/create_news_item.rb
@@ -32,7 +32,7 @@ module Mutations
 
     def resolve(**params)
       ResourceService.new(data_provider: context[:current_user].try(:data_provider))
-        .create(NewsItem, params)
+        .create(DataResource::NewsItem, params)
     end
   end
 end

--- a/app/graphql/mutations/create_point_of_interest.rb
+++ b/app/graphql/mutations/create_point_of_interest.rb
@@ -63,7 +63,7 @@ module Mutations
 
     def resolve(**params)
       ResourceService.new(data_provider: context[:current_user].try(:data_provider))
-        .create(PointOfInterest, params)
+        .create(DataResource::PointOfInterest, params)
     end
   end
 end

--- a/app/graphql/mutations/create_tour.rb
+++ b/app/graphql/mutations/create_tour.rb
@@ -58,7 +58,7 @@ module Mutations
 
     def resolve(**params)
       ResourceService.new(data_provider: context[:current_user].try(:data_provider))
-        .create(Tour, params)
+        .create(DataResource::Tour, params)
     end
   end
 end

--- a/app/graphql/mutations/destroy_record.rb
+++ b/app/graphql/mutations/destroy_record.rb
@@ -8,7 +8,7 @@ module Mutations
 
     type Types::DestroyType
 
-    RECORD_WHITELIST = ["EventRecord", "NewsItem", "PointOfInterest", "Tour"].freeze
+    RECORD_WHITELIST = ["DataResource::EventRecord", "DataResource::NewsItem", "DataResource::PointOfInterest", "DataResource::Tour"].freeze
 
     def resolve(id: nil, record_type:, external_id: nil)
       return error_status unless RECORD_WHITELIST.include?(record_type)

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -5,7 +5,7 @@ require "graphql/query_resolver"
 class Resolvers::EventRecordsSearch
   include SearchObject.module(:graphql)
 
-  scope { EventRecord.filtered_for_current_user(context[:current_user]) }
+  scope { DataResource::EventRecord.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::EventRecordType]
 

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -6,7 +6,7 @@ require "graphql/query_resolver"
 class Resolvers::NewsItemsSearch
   include SearchObject.module(:graphql)
 
-  scope { NewsItem.filtered_for_current_user(context[:current_user]) }
+  scope { DataResource::NewsItem.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::NewsItemType]
 

--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -6,7 +6,7 @@ require "graphql/query_resolver"
 class Resolvers::PointsOfInterestSearch
   include SearchObject.module(:graphql)
 
-  scope { PointOfInterest.filtered_for_current_user(context[:current_user]) }
+  scope { DataResource::PointOfInterest.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::PointOfInterestType]
 

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -6,7 +6,7 @@ require "graphql/query_resolver"
 class Resolvers::ToursSearch
   include SearchObject.module(:graphql)
 
-  scope { Tour.filtered_for_current_user(context[:current_user]) }
+  scope { DataResource::Tour.filtered_for_current_user(context[:current_user]) }
 
   type types[Types::TourType]
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -33,19 +33,19 @@ module Types
     field :categories, [CategoryType], null: false
 
     def point_of_interest(id:)
-      PointOfInterest.find(id)
+      DataResource::PointOfInterest.find(id)
     end
 
     def event_record(id:)
-      EventRecord.find(id)
+      DataResource::EventRecord.find(id)
     end
 
     def news_item(id:)
-      NewsItem.find(id)
+      DataResource::NewsItem.find(id)
     end
 
     def tour(id:)
-      Tour.find(id)
+      DataResource::Tour.find(id)
     end
 
     def categories

--- a/app/models/attraction.rb
+++ b/app/models/attraction.rb
@@ -33,7 +33,7 @@ class Attraction < ApplicationRecord
   # callback function which enables setting of category by
   # virtual attribute category name. ATTENTION: With this callback
   # the setting of category is only possible with category_name
-  # PointOfInterest.create(category: Category.first) doesn't work anymore.
+  # DataResource::PointOfInterest.create(category: Category.first) doesn't work anymore.
   #
   def set_category_id
     self.category_id = find_or_create_category.id

--- a/app/models/data_resource/event_record.rb
+++ b/app/models/data_resource/event_record.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # this model describes the data for an event e.g. a concert or a reading.
-class EventRecord < ApplicationRecord
+class DataResource::EventRecord < ApplicationRecord
   attr_accessor :category_name
   attr_accessor :region_name
   attr_accessor :force_create

--- a/app/models/data_resource/news_item.rb
+++ b/app/models/data_resource/news_item.rb
@@ -2,7 +2,7 @@
 
 # News Item is one of the four Main resources for the app. A news Item can be anything
 # from an old school news article to a whole story structured in chapters
-class NewsItem < ApplicationRecord
+class DataResource::NewsItem < ApplicationRecord
   attr_accessor :force_create
 
   belongs_to :data_provider

--- a/app/models/data_resource/point_of_interest.rb
+++ b/app/models/data_resource/point_of_interest.rb
@@ -4,7 +4,7 @@
 # All locations which are interesting and attractive for the public in the
 # smart village and the surrounding area
 #
-class PointOfInterest < Attraction
+class DataResource::PointOfInterest < Attraction
   attr_accessor :force_create
 
   has_many :opening_hours, as: :openingable, dependent: :destroy

--- a/app/models/data_resource/tour.rb
+++ b/app/models/data_resource/tour.rb
@@ -4,7 +4,7 @@
 # A Tour is a planned route to walk ride or canoe and which passes through
 # the surrounding areas of the Smart Village
 #
-class Tour < Attraction
+class DataResource::Tour < Attraction
   attr_accessor :force_create
 
   has_many :geometry_tour_data, as: :geo_locateable, class_name: "GeoLocation", dependent: :destroy

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -187,7 +187,7 @@ end
 create_categories
 
 10.times do |n|
-  poi = PointOfInterest.create(
+  poi = DataResource::PointOfInterest.create(
     name: "Burg #{n}",
     description: Faker::Lorem.paragraph,
     mobile_description: Faker::Lorem.paragraph,
@@ -212,7 +212,7 @@ create_categories
 end
 
 10.times do |n|
-  tour = Tour.create(
+  tour = DataResource::Tour.create(
     name: "Tour #{n}",
     description: Faker::Lorem.paragraph,
     mobile_description: Faker::Lorem.paragraph,
@@ -237,7 +237,7 @@ end
 end
 
 10.times do |n|
-  event = EventRecord.create(
+  event = DataResource::EventRecord.create(
     title: "Konzert #{n}",
     description: Faker::Lorem.paragraph,
     repeat: Faker::Boolean.boolean(0.3),
@@ -266,7 +266,7 @@ end
 end
 
 10.times do
-  news_item = NewsItem.create(
+  news_item = DataResource::NewsItem.create(
     author: Faker::Name.name,
     full_version: true,
     characters_to_be_shown: false,

--- a/spec/graphql/mutations/create_tour_spec.rb
+++ b/spec/graphql/mutations/create_tour_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Tour do
+RSpec.describe Mutations::CreateTour do
   def perform(**args)
     Mutations::CreateTour.new(object: nil, context: {}).resolve(args)
   end

--- a/spec/models/data_resource/event_record_spec.rb
+++ b/spec/models/data_resource/event_record_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe EventRecord, type: :model do
+RSpec.describe DataResource::EventRecord, type: :model do
   let(:event_record_2) { create(:event_record) }
   let(:event_record_1) { create(:event_record) }
 

--- a/spec/models/data_resource/news_item_spec.rb
+++ b/spec/models/data_resource/news_item_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe NewsItem, type: :model do
+RSpec.describe DataResource::NewsItem, type: :model do
   it { is_expected.to have_many(:content_blocks) }
   it { is_expected.to have_one(:address) }
   it { is_expected.to have_one(:data_provider) }

--- a/spec/models/data_resource/point_of_interest_spec.rb
+++ b/spec/models/data_resource/point_of_interest_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PointOfInterest, type: :model do
+RSpec.describe DataResource::PointOfInterest, type: :model do
   it { is_expected.to have_many(:addresses) }
   it { is_expected.to have_one(:contact) }
   it { is_expected.to have_one(:operating_company) }

--- a/spec/models/data_resource/tour_spec.rb
+++ b/spec/models/data_resource/tour_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Tour, type: :model do
+RSpec.describe DataResource::Tour, type: :model do
   it { is_expected.to have_many(:geometry_tour_data) }
   it { is_expected.to define_enum_for(:means_of_transportation) }
 end

--- a/spec/services/resource_service_spec.rb
+++ b/spec/services/resource_service_spec.rb
@@ -5,17 +5,17 @@ require "rails_helper"
 RSpec.describe ResourceService, type: :service do
   let(:maz) { create(:data_provider, name: "MAZ", news_item: true) }
   let(:tmb) { create(:data_provider, name: "TMB") }
-  let(:news_item_1) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
-  let(:news_item_2) { ResourceService.new(data_provider: maz).create(NewsItem, params_maz) }
-  let(:poi_1) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }
-  let(:poi_1_changed) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi_changed) }
-  let(:poi_2) { ResourceService.new(data_provider: tmb).create(PointOfInterest, params_tmb_poi) }
-  let(:tour_1) { ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
-  let(:tour_1_changed) { ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour_changed) }
-  let(:tour_2) { ResourceService.new(data_provider: tmb).create(Tour, params_tmb_tour) }
-  let(:event_1) { ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
-  let(:event_1_changed) { ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event_changed) }
-  let(:event_2) { ResourceService.new(data_provider: tmb).create(EventRecord, params_tmb_event) }
+  let(:news_item_1) { ResourceService.new(data_provider: maz).create(DataResource::NewsItem, params_maz) }
+  let(:news_item_2) { ResourceService.new(data_provider: maz).create(DataResource::NewsItem, params_maz) }
+  let(:poi_1) { ResourceService.new(data_provider: tmb).create(DataResource::PointOfInterest, params_tmb_poi) }
+  let(:poi_1_changed) { ResourceService.new(data_provider: tmb).create(DataResource::PointOfInterest, params_tmb_poi_changed) }
+  let(:poi_2) { ResourceService.new(data_provider: tmb).create(DataResource::PointOfInterest, params_tmb_poi) }
+  let(:tour_1) { ResourceService.new(data_provider: tmb).create(DataResource::Tour, params_tmb_tour) }
+  let(:tour_1_changed) { ResourceService.new(data_provider: tmb).create(DataResource::Tour, params_tmb_tour_changed) }
+  let(:tour_2) { ResourceService.new(data_provider: tmb).create(DataResource::Tour, params_tmb_tour) }
+  let(:event_1) { ResourceService.new(data_provider: tmb).create(DataResource::EventRecord, params_tmb_event) }
+  let(:event_1_changed) { ResourceService.new(data_provider: tmb).create(DataResource::EventRecord, params_tmb_event_changed) }
+  let(:event_2) { ResourceService.new(data_provider: tmb).create(DataResource::EventRecord, params_tmb_event) }
 
   def params_maz
     { author: "Robert sdf",
@@ -159,10 +159,10 @@ RSpec.describe ResourceService, type: :service do
         end
 
         it "deletes the old record" do
-          expect(NewsItem.exists?(news_item_1.id)).to eq(false)
+          expect(DataResource::NewsItem.exists?(news_item_1.id)).to eq(false)
         end
         it "creates a new record" do
-          expect(NewsItem.exists?(news_item_2.id)).to eq(true)
+          expect(DataResource::NewsItem.exists?(news_item_2.id)).to eq(true)
         end
         it "the new record has the same external_id as the old one" do
           expect(news_item_1.external_id).to eq(news_item_2.external_id)
@@ -210,17 +210,17 @@ RSpec.describe ResourceService, type: :service do
           expect(poi_1_changed.id).not_to eq(poi_1.id)
           expect(tour_1_changed.id).not_to eq(tour_1.id)
           expect(event_1_changed.id).not_to eq(event_1.id)
-          expect(PointOfInterest.exists?(poi_1_changed.id)).to eq(true)
-          expect(Tour.exists?(tour_1_changed.id)).to eq(true)
-          expect(EventRecord.exists?(event_1_changed.id)).to eq(true)
+          expect(DataResource::PointOfInterest.exists?(poi_1_changed.id)).to eq(true)
+          expect(DataResource::Tour.exists?(tour_1_changed.id)).to eq(true)
+          expect(DataResource::EventRecord.exists?(event_1_changed.id)).to eq(true)
         end
         it "destroys the old record" do
           poi_1_changed
           tour_1_changed
           event_1_changed
-          expect(PointOfInterest.exists?(poi_1.id)).to eq(false)
-          expect(Tour.exists?(tour_1.id)).to eq(false)
-          expect(EventRecord.exists?(event_1.id)).to eq(false)
+          expect(DataResource::PointOfInterest.exists?(poi_1.id)).to eq(false)
+          expect(DataResource::Tour.exists?(tour_1.id)).to eq(false)
+          expect(DataResource::EventRecord.exists?(event_1.id)).to eq(false)
         end
       end
     end


### PR DESCRIPTION
@marcometz Oktober 2019:
>[point_of_interest tour news_item event_record] sollen in den Models ein Namespacing bekommen.
>
>Offener TODO: Tour und POI sind STI von Attraction! Um das Namespacing abschließen zu können wird zusätzlich eine Migration >benötigt die die Werte in der STI Tabelle umschreibt

Wollen wir hier noch Dinge nachziehen oder Optimieren?