### PR TITLE
change time_description to text

### DIFF
--- a/app/models/data_resources/resource_modules/fixed_date.rb
+++ b/app/models/data_resources/resource_modules/fixed_date.rb
@@ -15,7 +15,7 @@ end
 #  weekday                   :string(255)
 #  time_start                :time
 #  time_end                  :time
-#  time_description          :string(255)
+#  time_description          :text(65535)
 #  use_only_time_description :boolean          default(FALSE)
 #  dateable_type             :string(255)
 #  dateable_id               :bigint

--- a/db/migrate/20210830070503_change_time_description_to_text.rb
+++ b/db/migrate/20210830070503_change_time_description_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeTimeDescriptionToText < ActiveRecord::Migration[5.2]
+  def change
+    change_column :fixed_dates, :time_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_02_072005) do
+ActiveRecord::Schema.define(version: 2021_08_30_070503) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 2021_07_02_072005) do
     t.string "weekday"
     t.time "time_start"
     t.time "time_end"
-    t.string "time_description"
+    t.text "time_description"
     t.boolean "use_only_time_description", default: false
     t.string "dateable_type"
     t.bigint "dateable_id"

--- a/spec/factories/fixed_dates.rb
+++ b/spec/factories/fixed_dates.rb
@@ -22,7 +22,7 @@ end
 #  weekday                   :string(255)
 #  time_start                :time
 #  time_end                  :time
-#  time_description          :string(255)
+#  time_description          :text(65535)
 #  use_only_time_description :boolean          default(FALSE)
 #  dateable_type             :string(255)
 #  dateable_id               :bigint

--- a/spec/models/fixed_date_spec.rb
+++ b/spec/models/fixed_date_spec.rb
@@ -16,7 +16,7 @@ end
 #  weekday                   :string(255)
 #  time_start                :time
 #  time_end                  :time
-#  time_description          :string(255)
+#  time_description          :text(65535)
 #  use_only_time_description :boolean          default(FALSE)
 #  dateable_type             :string(255)
 #  dateable_id               :bigint


### PR DESCRIPTION
added migration to change time_description from string to text to prevent import errors
by delivering long descriptions.

https://rollbar.com/SmartVillage/SmartVillage-Server/items/157

SVA-263