### PR TITLE
change mobile_description to text

### DIFF
--- a/app/models/data_resources/attraction.rb
+++ b/app/models/data_resources/attraction.rb
@@ -70,7 +70,7 @@ end
 #  id                      :bigint           not null, primary key
 #  name                    :string(255)
 #  description             :text(65535)
-#  mobile_description      :string(255)
+#  mobile_description      :text(65535)
 #  active                  :boolean          default(TRUE)
 #  length_km               :integer
 #  means_of_transportation :integer

--- a/app/models/data_resources/point_of_interest.rb
+++ b/app/models/data_resources/point_of_interest.rb
@@ -49,7 +49,7 @@ end
 #  id                      :bigint           not null, primary key
 #  name                    :string(255)
 #  description             :text(65535)
-#  mobile_description      :string(255)
+#  mobile_description      :text(65535)
 #  active                  :boolean          default(TRUE)
 #  length_km               :integer
 #  means_of_transportation :integer

--- a/app/models/data_resources/tour.rb
+++ b/app/models/data_resources/tour.rb
@@ -48,7 +48,7 @@ end
 #  id                      :bigint           not null, primary key
 #  name                    :string(255)
 #  description             :text(65535)
-#  mobile_description      :string(255)
+#  mobile_description      :text(65535)
 #  active                  :boolean          default(TRUE)
 #  length_km               :integer
 #  means_of_transportation :integer

--- a/db/migrate/20210830095926_change_mobile_description_to_text.rb
+++ b/db/migrate/20210830095926_change_mobile_description_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeMobileDescriptionToText < ActiveRecord::Migration[5.2]
+  def change
+    change_column :attractions, :mobile_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_30_070503) do
+ActiveRecord::Schema.define(version: 2021_08_30_095926) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2021_08_30_070503) do
   create_table "attractions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "description"
-    t.string "mobile_description"
+    t.text "mobile_description"
     t.boolean "active", default: true
     t.integer "length_km"
     t.integer "means_of_transportation"

--- a/spec/factories/tours.rb
+++ b/spec/factories/tours.rb
@@ -12,7 +12,7 @@ end
 #  id                      :bigint           not null, primary key
 #  name                    :string(255)
 #  description             :text(65535)
-#  mobile_description      :string(255)
+#  mobile_description      :text(65535)
 #  active                  :boolean          default(TRUE)
 #  length_km               :integer
 #  means_of_transportation :integer

--- a/spec/models/point_of_interest_spec.rb
+++ b/spec/models/point_of_interest_spec.rb
@@ -23,7 +23,7 @@ end
 #  id                      :bigint           not null, primary key
 #  name                    :string(255)
 #  description             :text(65535)
-#  mobile_description      :string(255)
+#  mobile_description      :text(65535)
 #  active                  :boolean          default(TRUE)
 #  length_km               :integer
 #  means_of_transportation :integer

--- a/spec/models/tour_spec.rb
+++ b/spec/models/tour_spec.rb
@@ -14,7 +14,7 @@ end
 #  id                      :bigint           not null, primary key
 #  name                    :string(255)
 #  description             :text(65535)
-#  mobile_description      :string(255)
+#  mobile_description      :text(65535)
 #  active                  :boolean          default(TRUE)
 #  length_km               :integer
 #  means_of_transportation :integer


### PR DESCRIPTION
added migration to change mobile_description from string to text to prevent import errors
by delivering long descriptions for model attractions.

SVA-263