### PR TITLE
feat(data provider): add notice field

### DIFF
--- a/app/controllers/data_provider_controller.rb
+++ b/app/controllers/data_provider_controller.rb
@@ -19,7 +19,7 @@ class DataProviderController < ApplicationController
             address: { only: [:addition, :street, :city, :zip] },
             contact: { only: [:first_name, :last_name, :phone, :fax, :email] }
           },
-          only: [:name, :description],
+          only: [:name, :description, :notice],
           root: true
         }
       else
@@ -55,7 +55,7 @@ class DataProviderController < ApplicationController
     end
 
     def provider_params
-      params.require(:data_provider).permit(:name, :description,
+      params.require(:data_provider).permit(:name, :description, :notice,
         address_attributes: [:addition, :city, :street, :zip, :id],
         contact_attributes: [:first_name, :last_name, :phone, :fax, :email, :id],
         logo_attributes: [:url, :description, :id])

--- a/app/graphql/types/input_types/data_provider_input.rb
+++ b/app/graphql/types/input_types/data_provider_input.rb
@@ -14,5 +14,6 @@ module Types
                                         as: :logo_attributes,
                                         prepare: ->(logo, _ctx) { logo.to_h }
     argument :description, String, required: false
+    argument :notice, String, required: false
   end
 end

--- a/app/graphql/types/query_types/data_provider_type.rb
+++ b/app/graphql/types/query_types/data_provider_type.rb
@@ -9,5 +9,6 @@ module Types
     field :description, String, null: true
     field :address, QueryTypes::AddressType, null: true
     field :contact, QueryTypes::ContactType, null: true
+    field :notice, String, null: true
   end
 end

--- a/app/models/data_provider.rb
+++ b/app/models/data_provider.rb
@@ -58,4 +58,5 @@ end
 #  always_recreate :text(65535)
 #  roles           :text(65535)
 #  data_type       :integer          default("general_importer")
+#  notice          :text(65535)
 #

--- a/app/models/survey/comment.rb
+++ b/app/models/survey/comment.rb
@@ -18,3 +18,15 @@ class Survey::Comment < ApplicationRecord
     includes(:poll).where(survey_polls: { data_provider_id: current_user.data_provider_id })
   }
 end
+
+# == Schema Information
+#
+# Table name: survey_comments
+#
+#  id             :bigint           not null, primary key
+#  survey_poll_id :integer
+#  message        :text(65535)
+#  visible        :boolean          default(FALSE)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#

--- a/app/models/survey/poll.rb
+++ b/app/models/survey/poll.rb
@@ -69,10 +69,11 @@ end
 #
 # Table name: survey_polls
 #
-#  id          :bigint           not null, primary key
-#  title       :text(4294967295)
-#  description :text(4294967295)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  visible     :boolean          default(TRUE)
+#  id               :bigint           not null, primary key
+#  title            :text(4294967295)
+#  description      :text(4294967295)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  visible          :boolean          default(TRUE)
+#  data_provider_id :integer
 #

--- a/app/views/data_provider/edit.html.erb
+++ b/app/views/data_provider/edit.html.erb
@@ -17,6 +17,11 @@
         <%= f.text_area :description, class: "form-control" %>
       </div>
 
+      <div class="form-group">
+        <%= f.label :notice %>
+        <%= f.text_area :notice, class: "form-control" %>
+      </div>
+
       <h2>Logo</h2>
       <%= f.fields_for :logo, f.object.logo || f.object.build_logo do |l| %>
         <div class="form-group">

--- a/db/migrate/20211109150013_add_notice_to_data_providers.rb
+++ b/db/migrate/20211109150013_add_notice_to_data_providers.rb
@@ -1,0 +1,5 @@
+class AddNoticeToDataProviders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :data_providers, :notice, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_30_095926) do
+ActiveRecord::Schema.define(version: 2021_11_09_150013) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2021_08_30_095926) do
     t.text "always_recreate"
     t.text "roles"
     t.integer "data_type", default: 0
+    t.text "notice"
   end
 
   create_table "data_resource_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -116,6 +116,7 @@ type DataProvider {
   id: ID
   logo: WebUrl
   name: String
+  notice: String
 }
 
 type Date {

--- a/public/schema.json
+++ b/public/schema.json
@@ -3556,6 +3556,20 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "notice",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/schema.graphql
+++ b/schema.graphql
@@ -116,6 +116,7 @@ type DataProvider {
   id: ID
   logo: WebUrl
   name: String
+  notice: String
 }
 
 type Date {

--- a/schema.json
+++ b/schema.json
@@ -3556,6 +3556,20 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "notice",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/spec/factories/data_providers.rb
+++ b/spec/factories/data_providers.rb
@@ -17,4 +17,5 @@ end
 #  always_recreate :text(65535)
 #  roles           :text(65535)
 #  data_type       :integer          default("general_importer")
+#  notice          :text(65535)
 #

--- a/spec/models/data_provider_spec.rb
+++ b/spec/models/data_provider_spec.rb
@@ -20,4 +20,5 @@ end
 #  always_recreate :text(65535)
 #  roles           :text(65535)
 #  data_type       :integer          default("general_importer")
+#  notice          :text(65535)
 #


### PR DESCRIPTION
- added `notice` to be able to set some additional text for data provider information, that can be displayed in the mobile app
  - html is possible
- updated graphql types and schema
- updated annotations
- added input to data provider form to be able to edit the notice

SVA-171

|data in db|data per grapqhl|edit notice|
|---|---|---|
|<img width="364" alt="Bildschirmfoto 2021-11-09 um 16 12 19" src="https://user-images.githubusercontent.com/1942953/140950667-f3790cac-be9b-4f3e-ad9b-151b248dfbf6.png">|<img width="657" alt="Bildschirmfoto 2021-11-09 um 16 12 29" src="https://user-images.githubusercontent.com/1942953/140950697-45f13804-d2a8-4660-98fb-86f56d549e54.png">|![Bildschirmfoto 2021-11-09 um 16 20 00](https://user-images.githubusercontent.com/1942953/140952278-1e38a8fe-e0e7-444d-aebe-7862607eb315.png)|