### PR TITLE
feat: add ability to query POIs and Tours with `categoryId`

### DIFF
--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -29,6 +29,7 @@ class Resolvers::PointsOfInterestSearch
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
+  option :categoryId, type: types.ID, with: :apply_category_id
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -56,6 +57,10 @@ class Resolvers::PointsOfInterestSearch
 
   def apply_category(scope, value)
     scope.joins(:categories).where(categories: { name: value })
+  end
+
+  def apply_category_id(scope, value)
+    scope.with_category(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -29,6 +29,7 @@ class Resolvers::ToursSearch
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
+  option :categoryId, type: types.ID, with: :apply_category_id
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -56,6 +57,10 @@ class Resolvers::ToursSearch
 
   def apply_category(scope, value)
     scope.joins(:categories).where(categories: { name: value })
+  end
+
+  def apply_category_id(scope, value)
+    scope.with_category(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/models/data_resources/attraction.rb
+++ b/app/models/data_resources/attraction.rb
@@ -23,6 +23,10 @@ class Attraction < ApplicationRecord
 
   scope :visible, -> { where(visible: true) }
 
+  scope :with_category, lambda { |category_id|
+    where(categories: { id: category_id }).joins(:categories)
+  }
+
   validates_presence_of :name
   acts_as_taggable
 

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -563,13 +563,13 @@ type Query {
   newsItems(categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
   newsItemsDataProviders(categoryId: ID): [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
-  pointsOfInterest(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
+  pointsOfInterest(category: String, categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!
   publicJsonFile(name: String!): PublicJsonFile!
   surveyComments(surveyId: ID): [SurveyComment!]!
   surveys(archived: Boolean, ids: [ID], ongoing: Boolean): [SurveyPoll!]!
   tour(id: ID!): Tour!
-  tours(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
+  tours(category: String, categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
   wasteAddresses(ids: [ID], limit: Int, order: WasteLocationOrder = createdAt_DESC, skip: Int): [Address!]!
   wasteLocationType(id: ID!): WasteLocationType!
   wasteLocationTypes: [WasteLocationType!]!

--- a/public/schema.json
+++ b/public/schema.json
@@ -772,6 +772,16 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "categoryId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -1047,6 +1057,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "categoryId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null

--- a/schema.graphql
+++ b/schema.graphql
@@ -563,13 +563,13 @@ type Query {
   newsItems(categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: NewsItemsOrder = publishedAt_DESC, skip: Int): [NewsItem]
   newsItemsDataProviders(categoryId: ID): [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
-  pointsOfInterest(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
+  pointsOfInterest(category: String, categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
   publicHtmlFile(name: String!): PublicHtmlFile!
   publicJsonFile(name: String!): PublicJsonFile!
   surveyComments(surveyId: ID): [SurveyComment!]!
   surveys(archived: Boolean, ids: [ID], ongoing: Boolean): [SurveyPoll!]!
   tour(id: ID!): Tour!
-  tours(category: String, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
+  tours(category: String, categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: ToursOrder = createdAt_DESC, skip: Int): [Tour!]!
   wasteAddresses(ids: [ID], limit: Int, order: WasteLocationOrder = createdAt_DESC, skip: Int): [Address!]!
   wasteLocationType(id: ID!): WasteLocationType!
   wasteLocationTypes: [WasteLocationType!]!

--- a/schema.json
+++ b/schema.json
@@ -772,6 +772,16 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "categoryId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -1047,6 +1057,16 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "categoryId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null


### PR DESCRIPTION
- added scope `with_category` and query option to points of interest and tours to attractions like it is already existing for news, event records and generic items
- updated graphql schema

SVA-353

---

you can query now like

```
{
  "limit": 100000,
  "order": "updatedAt_DESC",
  "categoryId": 3
}
```

the existing ability with `"category": "Schlösser und Parks"` is still available for pints of interest and tours.