### PR TITLE
feat(static contents): add versioned returns

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -45,10 +45,12 @@ module Types
 
     field :public_html_file, QueryTypes::PublicHtmlFileType, null: false do
       argument :name, String, required: true
+      argument :version, String, required: false
     end
 
     field :public_json_file, QueryTypes::PublicJsonFileType, null: false do
       argument :name, String, required: true
+      argument :version, String, required: false
     end
 
     field :news_items_data_providers, [QueryTypes::DataProviderType], null: false do
@@ -130,25 +132,21 @@ module Types
     # Provide contents from html files in `public/mobile-app/contents` through GraphQL query
     #
     # @param [String] name the file name
+    # @param [String] version an optional requested version number
     #
     # @return [Object] object with the contents of the file, if it exists - otherwise with ""
-    def public_html_file(name:)
-      static_content = StaticContent.where(name: name, data_type: "html").first
-      return { content: static_content.content, name: name } if static_content.present?
-
-      { content: "", name: "not found" }
+    def public_html_file(name:, version: nil)
+      static_content_with_data_type("html", name, version)
     end
 
     # Provide contents from json files in `public/mobile-app/configs` through GraphQL query
     #
     # @param [String] name the file name
+    # @param [String] version an optional requested version number
     #
     # @return [Object] object with the contents of the file, if it exists - otherwise with {}
-    def public_json_file(name:)
-      static_content = StaticContent.where(name: name, data_type: "json").first
-      return { content: static_content.content, name: name } if static_content.present?
-
-      { content: {}, name: "not found" }
+    def public_json_file(name:, version: nil)
+      static_content_with_data_type("json", name, version)
     end
 
     # PASS THROUGH FOR DIRECTUS ENDPOINT
@@ -186,6 +184,65 @@ module Types
       # @return [Boolean] true, if file is existing and included in the whitelist - otherwise false
       def query_file?(file, path, file_type)
         File.exist?(file) && query_files_whitelist(path, file_type).include?(file)
+      end
+
+      def static_content_with_data_type(data_type, name, version = nil)
+        # HINT: mysql REGEXP for /^#{name}(-\d\.\d\.\d)?$/ was not working fully somehow,
+        #       so we query for all contents starting with name and filter with rails afterwards
+        static_contents = StaticContent.where("data_type = '#{data_type}' AND name LIKE '#{name}%'")
+
+        # filter static contents matching name and version number
+        #
+        # examples given the name "someName" and version "1.2.3":
+        #   someName -> true
+        #   someName-1.2.3 -> true
+        #   someName-new -> false
+        #   someName-new-1.2.3 -> false
+        static_contents = static_contents.filter do |static_content|
+          static_content.name.match(/^#{name}(-\d\.\d\.\d)?$/)
+        end
+
+        static_content = find_static_content(static_contents, name, version)
+
+        return { content: static_content.content, name: name } if static_content.present?
+
+        { content: data_type == "html" ? "" : {}, name: "not found" }
+      end
+
+      # loop through static contents for a queried name an optionally queried version
+      #
+      # @param [Array] static_contents all entries to loop through
+      # @param [String] query_name the content name that was queried
+      # @param [String] query_version an optional content version number that was queried
+      #
+      # @return [Object] a (closest) versioned or an unversioned static content
+      def find_static_content(static_contents, query_name, query_version = nil)
+        max_version = nil # refers to 0.0.0 with Gem::Version
+        versioned_static_content = nil
+        unversioned_static_content = nil
+
+        static_contents.each do |static_content|
+          regex_group = static_content.name.match(/#{query_name}-(.+)/)
+
+          unless regex_group
+            unversioned_static_content = static_content
+            next
+          end
+
+          version = regex_group[1]
+
+          next unless Gem::Version.new(max_version) < Gem::Version.new(version) &&
+                      Gem::Version.new(version) <= Gem::Version.new(query_version)
+
+          max_version = version
+          versioned_static_content = static_content
+        end
+
+        return versioned_static_content if versioned_static_content
+
+        unversioned_static_content
+      rescue StandardError
+        nil
       end
   end
 end

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -2,7 +2,7 @@
 
 class StaticContent < ApplicationRecord
   validates_presence_of :name, :data_type
-  validates :name, uniqueness: { case_sensitive: false }
+  validates :name, uniqueness: { case_sensitive: false, scope: :version }
 
   scope :filter_by_type, ->(type) { where data_type: type }
 

--- a/db/migrate/20220117182809_add_version_to_static_contents.rb
+++ b/db/migrate/20220117182809_add_version_to_static_contents.rb
@@ -1,0 +1,5 @@
+class AddVersionToStaticContents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :static_contents, :version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_29_144638) do
+ActiveRecord::Schema.define(version: 2022_01_17_182809) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -426,6 +426,7 @@ ActiveRecord::Schema.define(version: 2021_11_29_144638) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "version"
   end
 
   create_table "survey_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -569,8 +569,8 @@ type Query {
   newsItemsDataProviders(categoryId: ID): [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
-  publicHtmlFile(name: String!): PublicHtmlFile!
-  publicJsonFile(name: String!): PublicJsonFile!
+  publicHtmlFile(name: String!, version: String): PublicHtmlFile!
+  publicJsonFile(name: String!, version: String): PublicJsonFile!
   surveyComments(surveyId: ID): [SurveyComment!]!
   surveys(archived: Boolean, ids: [ID], ongoing: Boolean): [SurveyPoll!]!
   tour(id: ID!): Tour!

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -43,6 +43,17 @@ type AppUserContent {
   updatedAt: String
 }
 
+enum CategoriesOrder {
+  createdAt_ASC
+  createdAt_DESC
+  id_ASC
+  id_DESC
+  name_ASC
+  name_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+}
+
 type Category {
   eventRecords: [EventRecord!]
   eventRecordsCount: Int
@@ -555,7 +566,7 @@ type PublicJsonFile {
 }
 
 type Query {
-  categories: [Category!]!
+  categories(ids: [ID], limit: Int, order: CategoriesOrder = name_ASC, skip: Int): [Category!]!
   categoryTree: JSON!
   directus(query: String): JSON!
   eventRecord(id: ID!): EventRecord!

--- a/public/schema.json
+++ b/public/schema.json
@@ -38,7 +38,50 @@
               "name": "categories",
               "description": null,
               "args": [
-
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "order",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CategoriesOrder",
+                    "ofType": null
+                  },
+                  "defaultValue": "name_ASC"
+                }
               ],
               "type": {
                 "kind": "NON_NULL",
@@ -6297,6 +6340,65 @@
             },
             {
               "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CategoriesOrder",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "name_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/public/schema.json
+++ b/public/schema.json
@@ -813,6 +813,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -842,6 +852,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -569,8 +569,8 @@ type Query {
   newsItemsDataProviders(categoryId: ID): [DataProvider!]!
   pointOfInterest(id: ID!): PointOfInterest!
   pointsOfInterest(category: String, categoryId: ID, dataProvider: String, dataProviderId: ID, ids: [ID], limit: Int, order: PointsOfInterestOrder = createdAt_DESC, skip: Int): [PointOfInterest]
-  publicHtmlFile(name: String!): PublicHtmlFile!
-  publicJsonFile(name: String!): PublicJsonFile!
+  publicHtmlFile(name: String!, version: String): PublicHtmlFile!
+  publicJsonFile(name: String!, version: String): PublicJsonFile!
   surveyComments(surveyId: ID): [SurveyComment!]!
   surveys(archived: Boolean, ids: [ID], ongoing: Boolean): [SurveyPoll!]!
   tour(id: ID!): Tour!

--- a/schema.graphql
+++ b/schema.graphql
@@ -43,6 +43,17 @@ type AppUserContent {
   updatedAt: String
 }
 
+enum CategoriesOrder {
+  createdAt_ASC
+  createdAt_DESC
+  id_ASC
+  id_DESC
+  name_ASC
+  name_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+}
+
 type Category {
   eventRecords: [EventRecord!]
   eventRecordsCount: Int
@@ -555,7 +566,7 @@ type PublicJsonFile {
 }
 
 type Query {
-  categories: [Category!]!
+  categories(ids: [ID], limit: Int, order: CategoriesOrder = name_ASC, skip: Int): [Category!]!
   categoryTree: JSON!
   directus(query: String): JSON!
   eventRecord(id: ID!): EventRecord!

--- a/schema.json
+++ b/schema.json
@@ -38,7 +38,50 @@
               "name": "categories",
               "description": null,
               "args": [
-
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "skip",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "order",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CategoriesOrder",
+                    "ofType": null
+                  },
+                  "defaultValue": "name_ASC"
+                }
               ],
               "type": {
                 "kind": "NON_NULL",
@@ -6297,6 +6340,65 @@
             },
             {
               "name": "RAND",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CategoriesOrder",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "name_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt_DESC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_ASC",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id_DESC",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/schema.json
+++ b/schema.json
@@ -813,6 +813,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -842,6 +852,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }


### PR DESCRIPTION
- added possibility to query for certain version numbers to get more feature specific static contents
- adjusted uniqueness validation to be able to have several static contents with the same name if there are different versions
- updated graphql schema

SVA-150

---

json:

```
query PublicJsonFile($name: String!, $version: String) {
  publicJsonFile(name: $name, version: $version) {
    content
  }
}

// variables with optional version
{
  "name": "wasteTypes",
  "version": "1.1.1"
}
```

returns `wasteTypes-1.1.1` or lower existing version like `wasteTypes-1.0.0` or without version `wasteTypes` if existing

---

html:

```
query PublicHtmlFile($name: String!, $version: String) {
  publicHtmlFile(name: $name, version: $version) {
    content
  }
}

// variables with optional version
{
  "name": "impressum",
  "version": "1.0.2"
}
```

returns `impressum-1.0.2` or lower existing version like `impressum-1.0.1` or without version `impressum` if existing