### PR TITLE
Refactor sorting in to concerns

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -8,12 +8,14 @@ class AccountsController < ApplicationController
   before_action :authenticate_user!
   before_action :authenticate_admin
 
+  include SortableController
+
   def authenticate_admin
     render inline: "not allowed", status: 404 unless current_user.admin_role?
   end
 
   def index
-    @users = User.all
+    @users = User.sorted_for_params(params)
   end
 
   def edit

--- a/app/controllers/concerns/sortable_controller.rb
+++ b/app/controllers/concerns/sortable_controller.rb
@@ -1,0 +1,14 @@
+# Controller Concern for Controllers that use models,
+# which include the 'Sortable' concern
+# Provides a helper for views to generate the sorting links
+module SortableController
+  extend ActiveSupport::Concern
+
+  def params_for_link(sort_column=nil)
+    Sortable.params_for_link(request.query_parameters.dup, sort_column)
+  end
+
+  included do
+    helper_method :params_for_link
+  end
+end

--- a/app/controllers/notification/devices_controller.rb
+++ b/app/controllers/notification/devices_controller.rb
@@ -3,6 +3,8 @@
 class Notification::DevicesController < ApplicationController
   layout "doorkeeper/admin"
 
+  include SortableController
+
   skip_before_action :verify_authenticity_token, only: [:create, :destroy]
 
   before_action :auth_user_or_doorkeeper, only: [:create, :destroy]
@@ -41,7 +43,7 @@ class Notification::DevicesController < ApplicationController
   # GET /notification/devices
   # GET /notification/devices.json
   def index
-    @notification_devices = Notification::Device.all
+    @notification_devices = Notification::Device.sorted_for_params(params)
     @push_logs = RedisAdapter.get_push_logs
   end
 

--- a/app/controllers/static_contents_controller.rb
+++ b/app/controllers/static_contents_controller.rb
@@ -6,6 +6,18 @@ class StaticContentsController < ApplicationController
   before_action :authenticate_user!
   before_action :authenticate_admin
 
+  include SortableController
+
+  def params_for_link(link_type, value=nil)
+    if link_type == :type
+      p = super()
+      p[:type] = value
+      p
+    else
+      super(link_type)
+    end
+  end
+
   before_action :set_static_content, only: [:show, :edit, :update, :destroy]
 
   def authenticate_admin
@@ -15,7 +27,7 @@ class StaticContentsController < ApplicationController
   # GET /static_contents
   # GET /static_contents.json
   def index
-    @static_contents = StaticContent.for_params(params)
+    @static_contents = StaticContent.sorted_and_filtered_for_params(params)
   end
 
   # GET /static_contents/1
@@ -71,33 +83,6 @@ class StaticContentsController < ApplicationController
       format.json { head :no_content }
     end
   end
-
-  # Helper method to get the right params for the right context, if:
-  # 1) user clicks on type filter -> preserve sorting of id or name
-  # 2) user clicks on id -> sort for id[asc/desc], preserve type, delete name sorting
-  # 3) user clicks on name -> sort for name[asc/desc], preserve type, delete id sorting
-  #
-  # TODO: Write tests for this method (?)
-  def params_for_link(link_type, type=nil)
-    p = Hash.new
-
-    if link_type == :type
-      p[:name] = params[:name] if params[:name].present?
-      p[:id] = params[:id] if params[:id].present?
-      p[:type] = type if type.present?
-    else
-      p[:type] = params[:type] if params[:type].present?
-
-      if link_type == :name
-        p[:name] = params[:name] == 'desc' ? 'asc' : 'desc'
-      elsif link_type == :id
-        p[:id] = params[:id] == 'desc' ? 'asc' : 'desc'
-      end
-    end
-
-    p
-  end
-  helper_method :params_for_link
 
   private
 

--- a/app/controllers/static_contents_controller.rb
+++ b/app/controllers/static_contents_controller.rb
@@ -8,8 +8,11 @@ class StaticContentsController < ApplicationController
 
   include SortableController
 
+  # We are overwriting SortableController#params_for_link here
   def params_for_link(link_type, value=nil)
     if link_type == :type
+      # Although we are not inheriting, this still calls SortableController
+      # because including actually puts the Module in the Ancestor chain
       p = super()
       p[:type] = value
       p

--- a/app/models/concerns/sortable.rb
+++ b/app/models/concerns/sortable.rb
@@ -1,0 +1,75 @@
+# The code in here is a bit complicated.
+# I wanted to be able to use include with arguments.
+# Read this blogpost: https://cutt.ly/jUr8M8f
+class Sortable < Module
+
+  #
+  # *fields are the fields which can be sorted
+  # 
+  def initialize(*fields)
+    # super() with brackets calls super with no arguments.
+    # Otherwise the would get passed and would throw an error
+    super() do
+
+      # Create an anonymous Module and store it in a local variable
+      # It will contain all the class methods which are later appended
+      # to the ActiveRecord Model.
+      #
+      # For example:
+      # class Model < ActiveRecord::Base
+      #   include Sortable.new :name, :email
+      # end
+      #
+      # Would lead to:
+      # Model.sorted_by_name(order)
+      # Model.sorted_by_email(order)
+      singleton_methods = Module.new do
+        fields.each do |field|
+          method_name = "sorted_by_#{field}".to_sym
+          define_method(method_name) do |order|
+            p = Hash.new
+            p[field] = order
+            order(p)
+          end
+
+        end
+
+        define_method(:sorted_fields) do
+          fields
+        end
+
+        # This class methods returns all records sorted for the specified
+        # column and specified order
+        #
+        # If column is not given or invalid, it returns all records
+        define_method(:sorted_for_params) do |params|
+          if params[:sort_column].present? && params[:sort_order].present?
+            if self.sorted_fields.include?(params[:sort_column].to_sym)
+              method_name = "sorted_by_#{params[:sort_column]}".to_sym
+              return self.send(method_name, params[:sort_order])
+            end
+          end
+
+          self.all
+        end
+      end
+      
+      # We can't just use 'def self.included' here, because we
+      # need accesss to the local variable
+      define_singleton_method :included do |base|
+        base.extend singleton_methods
+      end
+    end
+  end
+
+  def self.params_for_link(params, sort_column=nil)
+    return params if sort_column.nil?
+
+    sort_order = params[:sort_order] == 'asc' ? 'desc' : 'asc'
+
+    params.merge({
+      sort_column: sort_column,
+      sort_order: sort_order
+    })
+  end
+end

--- a/app/models/concerns/sortable.rb
+++ b/app/models/concerns/sortable.rb
@@ -26,9 +26,9 @@ class Sortable < Module
       singleton_methods = Module.new do
         fields.each do |field|
           method_name = "sorted_by_#{field}".to_sym
-          define_method(method_name) do |order|
-            p = Hash.new
-            p[field] = order
+          define_method(method_name) do |sort_order|
+            parameters = Hash.new
+            parameters[field] = sort_order
             order(p)
           end
 

--- a/app/models/notification/device.rb
+++ b/app/models/notification/device.rb
@@ -4,7 +4,8 @@ class Notification::Device < ApplicationRecord
   enum device_type: { undefined: 0, ios: 1, android: 2 }
   has_many :waste_registrations, class_name: "Waste::DeviceRegistration", primary_key: "token", foreign_key: "notification_device_token"
 
-  include Sortable.new :device_type, :token
+  include Sortable
+  sortable_on :device_type, :token
 
   # Zusätzlich zu der Validierung hier existiert auch ein unique Index auf das Feld 'token'
   validates_uniqueness_of :token, on: :create, message: "must be unique"

--- a/app/models/notification/device.rb
+++ b/app/models/notification/device.rb
@@ -4,6 +4,8 @@ class Notification::Device < ApplicationRecord
   enum device_type: { undefined: 0, ios: 1, android: 2 }
   has_many :waste_registrations, class_name: "Waste::DeviceRegistration", primary_key: "token", foreign_key: "notification_device_token"
 
+  include Sortable.new :device_type, :token
+
   # Zusätzlich zu der Validierung hier existiert auch ein unique Index auf das Feld 'token'
   validates_uniqueness_of :token, on: :create, message: "must be unique"
   validates_presence_of :token, on: :create, message: "can't be blank"

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -5,23 +5,14 @@ class StaticContent < ApplicationRecord
   validates :name, uniqueness: { case_sensitive: false }
 
   scope :filter_by_type, ->(type) { where data_type: type }
-  scope :ordered_by_name, ->(order) { order(name: order) }
-  scope :ordered_by_id, ->(order) { order(id: order) }
+  include Sortable.new :name, :id
 
-  def self.for_params(params)
-    static_contents = StaticContent.all
-
-    if params[:type].present?
-      static_contents = static_contents.filter_by_type(params[:type])
+  def self.sorted_and_filtered_for_params(params)
+    if params[:type]
+      self.sorted_for_params(params).filter_by_type(params[:type])
+    else
+      self.sorted_for_params(params)
     end
-
-    if params[:id].present?
-      static_contents = static_contents.ordered_by_id(params[:id].to_sym)
-    elsif params[:name].present?
-      static_contents = static_contents.ordered_by_name(params[:name].to_sym)
-    end
-
-    static_contents
   end
 end
 

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -8,11 +8,10 @@ class StaticContent < ApplicationRecord
   include Sortable.new :name, :id
 
   def self.sorted_and_filtered_for_params(params)
-    if params[:type]
-      self.sorted_for_params(params).filter_by_type(params[:type])
-    else
-      self.sorted_for_params(params)
-    end
+    sorted_results = self.sorted_for_params(params)
+    sorted_results = sorted_results.filter_by_type(params[:type]) if params[:type].present?
+
+    sorted_results
   end
 end
 

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -5,7 +5,8 @@ class StaticContent < ApplicationRecord
   validates :name, uniqueness: { case_sensitive: false }
 
   scope :filter_by_type, ->(type) { where data_type: type }
-  include Sortable.new :name, :id
+  include Sortable
+  sortable_on :name, :id
 
   def self.sorted_and_filtered_for_params(params)
     sorted_results = self.sorted_for_params(params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :validatable, :lockable, :timeoutable, :token_authenticatable
   enum role: { user: 0, admin: 1, app: 2, restricted: 3, editor: 4, read_only: 5 }, _suffix: :role
 
-  include Sortable.new :email, :id
+  include Sortable
+  sortable_on :email, :id
 
   belongs_to :data_provider, optional: true
   accepts_nested_attributes_for :data_provider

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :validatable, :lockable, :timeoutable, :token_authenticatable
   enum role: { user: 0, admin: 1, app: 2, restricted: 3, editor: 4, read_only: 5 }, _suffix: :role
 
+  include Sortable.new :email, :id
+
   belongs_to :data_provider, optional: true
   accepts_nested_attributes_for :data_provider
 

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -53,15 +53,21 @@
       </tbody>
     </table>
 
-    <h1>Nutzerverwaltung</h1>
+    <h1 id="accounts">Nutzerverwaltung</h1>
 
     <p><%= link_to "Neuen Nutzer erstellen", new_account_path, class: 'btn btn-success' %></p>
 
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>E-Mail</th>
+          <th style="min-width: 55px">
+            <%= link_to "ID", accounts_path(params_for_link(:id)) + "#accounts" %>
+            <%= render partial: 'sort_icon', locals: { sort_column: 'id' } %>
+          </th>
+          <th>
+            <%= link_to "E-Mail", accounts_path(params_for_link(:email)) + "#accounts" %>
+            <%= render partial: 'sort_icon', locals: { sort_column: 'email' } %>
+          </th>
           <th>Data Provider</th>
           <th>Rolle</th>
           <th>CMS POI <span class="badge badge-secondary">Kategorie gesetzt?</span></th>

--- a/app/views/application/_sort_icon.html.erb
+++ b/app/views/application/_sort_icon.html.erb
@@ -1,0 +1,11 @@
+<span class="sort-icon">
+  <% if params[:sort_column] == sort_column %>
+    <% if params[:sort_order] == 'desc' %>
+      <i class="fas fa-sort-down"></i>
+    <% elsif params[:sort_order] == 'asc' %>
+      <i class="fas fa-sort-up"></i>
+    <% end %>
+  <% else %>
+    <i class="fas fa-sort"></i>
+  <% end %>
+</span>

--- a/app/views/notification/devices/index.html.erb
+++ b/app/views/notification/devices/index.html.erb
@@ -6,15 +6,21 @@
 
     <br />
 
-    <h1>Devices</h1>
+    <h1 id="devices">Devices</h1>
 
     <p><%= link_to 'New Device', new_notification_device_path, class: "btn btn-success" %></p>
 
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>Token</th>
-          <th>Operating system</th>
+          <th>
+            <%= link_to "Token", notification_devices_path(params_for_link(:token)) + "#devices" %>
+            <%= render partial: 'sort_icon', locals: { sort_column: 'token' } %>
+          </th>
+          <th>
+            <%= link_to "Operating System", notification_devices_path(params_for_link(:device_type)) + "#devices" %>
+            <%= render partial: 'sort_icon', locals: { sort_column: 'device_type' } %>
+          </th>
           <th></th>
           <th></th>
         </tr>

--- a/app/views/static_contents/index.html.erb
+++ b/app/views/static_contents/index.html.erb
@@ -22,31 +22,11 @@
         <tr>
           <th>
             <%= link_to "ID", static_contents_path(params_for_link(:id)) %>
-            <span class="sort-icon">
-              <% if params[:sort_column] == 'id' %>
-                <% if params[:sort_order] == 'desc' %>
-                  <i class="fas fa-sort-down"></i>
-                <% elsif params[:sort_order] == 'asc' %>
-                  <i class="fas fa-sort-up"></i>
-                <% end %>
-              <% else %>
-                <i class="fas fa-sort"></i>
-              <% end %>
-            </span>
+            <%= render partial: 'sort_icon', locals: { sort_column: 'id' } %>
           </th>
           <th>
             <%= link_to "Name", static_contents_path(params_for_link(:name)) %>
-            <span class="sort-icon">
-              <% if params[:sort_column] == 'name' %>
-                <% if params[:sort_order] == 'desc' %>
-                  <i class="fas fa-sort-down"></i>
-                <% elsif params[:sort_order] == 'asc' %>
-                  <i class="fas fa-sort-up"></i>
-                <% end %>
-              <% else %>
-                <i class="fas fa-sort"></i>
-              <% end %>
-            </span>
+            <%= render partial: 'sort_icon', locals: { sort_column: 'name' } %>
           </th>
           <th>Type</th>
           <th></th>

--- a/app/views/static_contents/index.html.erb
+++ b/app/views/static_contents/index.html.erb
@@ -23,10 +23,12 @@
           <th>
             <%= link_to "ID", static_contents_path(params_for_link(:id)) %>
             <span class="sort-icon">
-              <% if params[:id] == 'desc' %>
-                <i class="fas fa-sort-down"></i>
-              <% elsif params[:id] == 'asc' %>
-                <i class="fas fa-sort-up"></i>
+              <% if params[:sort_column] == 'id' %>
+                <% if params[:sort_order] == 'desc' %>
+                  <i class="fas fa-sort-down"></i>
+                <% elsif params[:sort_order] == 'asc' %>
+                  <i class="fas fa-sort-up"></i>
+                <% end %>
               <% else %>
                 <i class="fas fa-sort"></i>
               <% end %>
@@ -35,10 +37,12 @@
           <th>
             <%= link_to "Name", static_contents_path(params_for_link(:name)) %>
             <span class="sort-icon">
-              <% if params[:name] == 'desc' %>
-                <i class="fas fa-sort-down"></i>
-              <% elsif params[:name] == 'asc' %>
-                <i class="fas fa-sort-up"></i>
+              <% if params[:sort_column] == 'name' %>
+                <% if params[:sort_order] == 'desc' %>
+                  <i class="fas fa-sort-down"></i>
+                <% elsif params[:sort_order] == 'asc' %>
+                  <i class="fas fa-sort-up"></i>
+                <% end %>
               <% else %>
                 <i class="fas fa-sort"></i>
               <% end %>

--- a/spec/models/concerns/sortable_spec.rb
+++ b/spec/models/concerns/sortable_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe Sortable do
+
+  fields = [:email, :role]
+
+  let(:params) { {} }
+  let(:dummy_class) { class_for_fields(*fields) }
+
+  it "should add sorting class methods for specified fields" do
+    dummy_class1 = class_for_fields(:email) 
+    dummy_class2 = class_for_fields(:role) 
+    dummy_class3 = class_for_fields(:email, :role) 
+
+    expect(dummy_class1).to respond_to(:sorted_by_email)
+    expect(dummy_class2).to respond_to(:sorted_by_role)
+    expect(dummy_class3).to respond_to(:sorted_by_email)
+    expect(dummy_class3).to respond_to(:sorted_by_role)
+  end
+
+  describe ".sorted_for_params" do
+
+    subject { dummy_class.sorted_for_params(params) }
+
+    before do
+      dummy_class.create(email: 'bernd@hotmail.de', role: 0)
+      dummy_class.create(email: 'sophie@web.de', role: 3)
+      dummy_class.create(email: 'peter@gmail.com', role: 2)
+      dummy_class.create(email: 'juergen@gmx.net', role: 0)
+      dummy_class.create(email: 'achim@protonmail.com', role: 1)
+    end
+
+    context "without params" do
+      it { is_expected.to eq(dummy_class.all) }
+    end
+
+    fields.each do |field|
+      context "with sort_column: #{field} and" do
+
+        ['asc', 'desc'].each do |order|
+          context "sort_oder: #{order}" do
+            let(:params) { { sort_column: field, sort_order: order } }
+            it { expect(subject).to eq(dummy_class.send("sorted_by_#{field}", order)) }
+          end
+        end
+
+      end
+    end
+
+  end
+
+  describe ".params_for_link" do
+
+    subject { Sortable.params_for_link(params, sort_column) }
+
+    context "without sort_column" do
+
+      let(:sort_column) { nil }
+
+      it { is_expected.to eq(params) }
+    end
+
+    context "with sort_column" do
+
+      let(:sort_column) { 'email' }
+
+      context "and no sort_order" do
+        default_sort_order = 'asc'
+
+        it "should default sort_order to #{default_sort_order}" do
+          is_expected.to eq({
+            sort_column: sort_column,
+            sort_order: default_sort_order
+          })
+        end
+      end
+
+      context "sort_column changes" do
+        let(:params) { { sort_column: 'role', sort_order: 'asc' } }
+
+        it "should change sort_column and reverse sort_order" do
+          is_expected.to eq({
+            sort_column: sort_column,
+            sort_order: 'desc'
+          })
+        end
+      end
+
+
+      context "same sort_column" do
+        let(:params) { { sort_column: sort_column, sort_order: 'asc' } }
+
+        it "should keep sort_column and reverse sort_order" do
+          is_expected.to eq({
+            sort_column: sort_column,
+            sort_order: 'desc'
+          })
+        end
+      end
+    end
+  end
+end
+
+def class_for_fields(*fields)
+  Class.new(ActiveRecord::Base) do
+    self.table_name = 'users'
+
+    include Sortable.new *fields
+  end
+end

--- a/spec/models/concerns/sortable_spec.rb
+++ b/spec/models/concerns/sortable_spec.rb
@@ -2,21 +2,34 @@ require 'rails_helper'
 
 RSpec.describe Sortable do
 
-  fields = [:email, :role]
+  sort_columns = [:email, :role]
 
   let(:params) { {} }
-  let(:dummy_class) { class_for_fields(*fields) }
+  let(:dummy_class) { class_for_sort_columns(*sort_columns) }
 
-  it "should add sorting class methods for specified fields" do
-    dummy_class1 = class_for_fields(:email) 
-    dummy_class2 = class_for_fields(:role) 
-    dummy_class3 = class_for_fields(:email, :role) 
+  context "without sort_columns provided" do
+    let(:dummy_class) { class_without_sort_columns }
 
-    expect(dummy_class1).to respond_to(:sorted_by_email)
-    expect(dummy_class2).to respond_to(:sorted_by_role)
-    expect(dummy_class3).to respond_to(:sorted_by_email)
-    expect(dummy_class3).to respond_to(:sorted_by_role)
+    it "should throw an error" do
+
+      expect { dummy_class.sorted_for_params(params) }
+        .to raise_error(Sortable::SortColumnsNotProvidedError)
+    end
   end
+
+  context "with sort_columns provided" do
+    it "should add sorting class methods for specified sort_columns" do
+      dummy_class1 = class_for_sort_columns(:email) 
+      dummy_class2 = class_for_sort_columns(:role) 
+      dummy_class3 = class_for_sort_columns(:email, :role) 
+
+      expect(dummy_class1).to respond_to(:sorted_by_email)
+      expect(dummy_class2).to respond_to(:sorted_by_role)
+      expect(dummy_class3).to respond_to(:sorted_by_email)
+      expect(dummy_class3).to respond_to(:sorted_by_role)
+    end
+  end
+
 
   describe ".sorted_for_params" do
 
@@ -34,7 +47,7 @@ RSpec.describe Sortable do
       it { is_expected.to eq(dummy_class.all) }
     end
 
-    fields.each do |field|
+    sort_columns.each do |field|
       context "with sort_column: #{field} and" do
 
         ['asc', 'desc'].each do |order|
@@ -101,10 +114,19 @@ RSpec.describe Sortable do
   end
 end
 
-def class_for_fields(*fields)
+def class_for_sort_columns(*sort_columns)
   Class.new(ActiveRecord::Base) do
     self.table_name = 'users'
 
-    include Sortable.new *fields
+    include Sortable
+    sortable_on *sort_columns
+  end
+end
+
+def class_without_sort_columns
+  Class.new(ActiveRecord::Base) do
+    self.table_name = 'users'
+
+    include Sortable
   end
 end

--- a/spec/models/static_content_spec.rb
+++ b/spec/models/static_content_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe StaticContent, type: :model do
   it { is_expected.to validate_presence_of(:data_type) }
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
 
-  describe ".for_params" do
+  describe ".sorted_and_filtered_for_params" do
 
     let(:params) { {} }
-    subject { StaticContent.for_params(params) }
+    subject { StaticContent.sorted_and_filtered_for_params(params) }
 
     before do
       FactoryBot.create(:static_content, name: 'N', data_type: 'html')
@@ -38,9 +38,9 @@ RSpec.describe StaticContent, type: :model do
     context "with name" do
       ['asc', 'desc'].each do |order|
         context order do
-          let(:params) { { name: order } }
+          let(:params) { { sort_column: 'name', sort_order: order } }
 
-          it { expect(subject).to eq(StaticContent.ordered_by_name(order)) }
+          it { expect(subject).to eq(StaticContent.sorted_by_name(order)) }
         end
       end
     end
@@ -48,9 +48,9 @@ RSpec.describe StaticContent, type: :model do
     context "with id" do
       ['asc', 'desc'].each do |order|
         context order do
-          let(:params) { { id: order } }
+          let(:params) { { sort_column: 'id', sort_order: order } }
 
-          it { expect(subject).to eq(StaticContent.ordered_by_id(order)) }
+          it { expect(subject).to eq(StaticContent.sorted_by_id(order)) }
         end
       end
     end
@@ -60,15 +60,15 @@ RSpec.describe StaticContent, type: :model do
       let(:type) { 'html' }
 
       context "id" do
-        let(:params) { { id: order, type: type } }
+        let(:params) { { sort_column: 'id', sort_order: order, type: type } }
         it { expect(subject.count).to eq(2) }
-        it { expect(subject).to eq(StaticContent.filter_by_type(type).ordered_by_id(order)) }
+        it { expect(subject).to eq(StaticContent.filter_by_type(type).sorted_by_id(order)) }
       end
 
       context "name" do
-        let(:params) { { name: order, type: type } }
+        let(:params) { { sort_column: 'name', sort_order: order, type: type } }
         it { expect(subject.count).to eq(2) }
-        it { expect(subject).to eq(StaticContent.filter_by_type(type).ordered_by_name(order)) }
+        it { expect(subject).to eq(StaticContent.filter_by_type(type).sorted_by_name(order)) }
       end
     end
   end


### PR DESCRIPTION
~~One model "concern" that is actually just a module with some meta-programming magic, because I wanted to use `include` it with parameters to instantly say which fields can be sorted.~~

We now use a "real" `ActiveSupport::Concern` here for simplicity and include a
`sortable_on :field1, :field2`
syntax, which looks more rails-ish.

One controller concern to use the sortable features in that controller and add the `helper_method` for the view