### PR TITLE
[SVA-398] Search admin interface

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -4,3 +4,9 @@
   line-height: 1.5;
   padding: 0 0.25rem;
 }
+
+.form-inline {
+  .btn {
+    margin: 0 5px;
+  }
+}

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -15,7 +15,9 @@ class AccountsController < ApplicationController
   end
 
   def index
-    @users = User.sorted_for_params(params)
+    @users = User
+      .sorted_for_params(params)
+      .where_email_contains(params[:query])
   end
 
   def edit

--- a/app/controllers/notification/devices_controller.rb
+++ b/app/controllers/notification/devices_controller.rb
@@ -43,7 +43,9 @@ class Notification::DevicesController < ApplicationController
   # GET /notification/devices
   # GET /notification/devices.json
   def index
-    @notification_devices = Notification::Device.sorted_for_params(params)
+    @notification_devices = Notification::Device
+      .sorted_for_params(params)
+      .where_token_contains(params[:query])
     @push_logs = RedisAdapter.get_push_logs
   end
 

--- a/app/controllers/static_contents_controller.rb
+++ b/app/controllers/static_contents_controller.rb
@@ -9,7 +9,7 @@ class StaticContentsController < ApplicationController
   include SortableController
 
   # We are overwriting SortableController#params_for_link here
-  def params_for_link(link_type, value=nil)
+  def params_for_link(link_type, value = nil)
     if link_type == :type
       # Although we are not inheriting, this still calls SortableController
       # because including actually puts the Module in the Ancestor chain

--- a/app/controllers/static_contents_controller.rb
+++ b/app/controllers/static_contents_controller.rb
@@ -30,7 +30,9 @@ class StaticContentsController < ApplicationController
   # GET /static_contents
   # GET /static_contents.json
   def index
-    @static_contents = StaticContent.sorted_and_filtered_for_params(params)
+    @static_contents = StaticContent
+      .sorted_and_filtered_for_params(params)
+      .where_name_contains(params[:query])
   end
 
   # GET /static_contents/1

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,0 +1,31 @@
+# Provide simple searching (per field) capability on model
+# TODO: Maybe add functionality to search on multiple fields at once
+module Searchable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+
+    # Example:
+    # class Model < ActiveRecord::Base
+    #   include Searchable
+    #   searchable_on :email, :name
+    # end
+    #
+    # Generates:
+    # Model.where_email_contains(query)
+    # Model.where_name_contains(query)
+    def searchable_on(*search_columns)
+      search_columns.each do |search_column|
+        method_name = "where_#{search_column}_contains".to_sym
+
+        define_singleton_method(method_name) do |search_query|
+          if search_query.present?
+            self.where("#{search_column} LIKE '%#{search_query}%'")
+          else
+            self.all
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 # Provide simple searching (per field) capability on model
 # TODO: Maybe add functionality to search on multiple fields at once
 module Searchable
   extend ActiveSupport::Concern
 
   module ClassMethods
-
     # Example:
     # class Model < ActiveRecord::Base
     #   include Searchable
@@ -20,9 +21,9 @@ module Searchable
 
         define_singleton_method(method_name) do |search_query|
           if search_query.present?
-            self.where("#{search_column} LIKE '%#{search_query}%'")
+            where("#{search_column} LIKE '%#{search_query}%'")
           else
-            self.all
+            all
           end
         end
       end

--- a/app/models/notification/device.rb
+++ b/app/models/notification/device.rb
@@ -7,6 +7,9 @@ class Notification::Device < ApplicationRecord
   include Sortable
   sortable_on :device_type, :token
 
+  include Searchable
+  searchable_on :token
+
   # Zusätzlich zu der Validierung hier existiert auch ein unique Index auf das Feld 'token'
   validates_uniqueness_of :token, on: :create, message: "must be unique"
   validates_presence_of :token, on: :create, message: "can't be blank"

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -13,7 +13,7 @@ class StaticContent < ApplicationRecord
   searchable_on :name
 
   def self.sorted_and_filtered_for_params(params)
-    sorted_results = self.sorted_for_params(params)
+    sorted_results = sorted_for_params(params)
     sorted_results = sorted_results.filter_by_type(params[:type]) if params[:type].present?
 
     sorted_results

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -5,8 +5,12 @@ class StaticContent < ApplicationRecord
   validates :name, uniqueness: { case_sensitive: false }
 
   scope :filter_by_type, ->(type) { where data_type: type }
+
   include Sortable
   sortable_on :name, :id
+
+  include Searchable
+  searchable_on :name
 
   def self.sorted_and_filtered_for_params(params)
     sorted_results = self.sorted_for_params(params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,9 @@ class User < ApplicationRecord
   include Sortable
   sortable_on :email, :id
 
+  include Searchable
+  searchable_on :email
+
   belongs_to :data_provider, optional: true
   accepts_nested_attributes_for :data_provider
 

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -57,6 +57,8 @@
 
     <p><%= link_to "Neuen Nutzer erstellen", new_account_path, class: 'btn btn-success' %></p>
 
+    <%= render partial: 'search_form', locals: { form_path: accounts_path, search_column: 'email' } %>
+
     <table class="table table-striped">
       <thead>
         <tr>

--- a/app/views/application/_search_form.html.erb
+++ b/app/views/application/_search_form.html.erb
@@ -1,0 +1,21 @@
+<form class="form-inline" method="get" action="<%= form_path %>">
+  <div class="form-group mb-2">
+    <input
+      id="query"
+      placeholder="<%= "#{search_column.capitalize} durchsuchen" %>"
+      name="query"
+      type="search"
+      value="<%= request.query_parameters[:query] %>"
+      class="form-control"
+    />
+  </div>
+
+  <button type="submit" class="btn btn-primary mb-2">Suchen</button>
+  <button type="submit" class="btn btn-warning mb-2" onClick="$('#query').val('');">Alles anzeigen</button>
+
+  <%# Preserve other parameters, e.g. for sorting %>
+  <% request.query_parameters.each do |key, value| %>
+    <% next if key == 'query' %>
+    <input type="hidden" name="<%= key %>" value="<%= value %>" />
+  <% end %>
+</form>

--- a/app/views/application/_search_form.html.erb
+++ b/app/views/application/_search_form.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group mb-2">
     <input
       id="query"
-      placeholder="<%= "#{search_column.capitalize} durchsuchen" %>"
+      placeholder="<%= t("search_column.#{search_column}") + " durchsuchen" %>"
       name="query"
       type="search"
       value="<%= request.query_parameters[:query] %>"

--- a/app/views/notification/devices/index.html.erb
+++ b/app/views/notification/devices/index.html.erb
@@ -10,6 +10,8 @@
 
     <p><%= link_to 'New Device', new_notification_device_path, class: "btn btn-success" %></p>
 
+    <%= render partial: 'search_form', locals: { form_path: notification_devices_path, search_column: 'token' } %>
+
     <table class="table table-striped">
       <thead>
         <tr>

--- a/app/views/static_contents/index.html.erb
+++ b/app/views/static_contents/index.html.erb
@@ -17,6 +17,8 @@
       <a href="<%= static_contents_path(params_for_link(:type, "html")) %>" class="btn <%= btn_class("html") %>">HTML</a>
     </div>
 
+    <%= render partial: 'search_form', locals: { form_path: static_contents_path, search_column: 'name' } %>
+
     <table class="table table-striped">
       <thead>
         <tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,7 @@
 
 en:
   hello: "Hello world"
+  search_column:
+    email: "E-Mail"
+    name: "Name"
+    token: "Token"

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -1,15 +1,16 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe Searchable do
-
-  search_columns = [:data_type, :name]
+  search_columns = %i[data_type name]
   let(:dummy_class) { class_for_search_columns(*search_columns) }
 
   context "with searchable_on called" do
-    it "should add searching class methods for specified search_columns" do
-      dummy_class1 = class_for_search_columns(:name) 
-      dummy_class2 = class_for_search_columns(:type) 
-      dummy_class3 = class_for_search_columns(:name, :type) 
+    it "adds searching class methods for specified search_columns" do
+      dummy_class1 = class_for_search_columns(:name)
+      dummy_class2 = class_for_search_columns(:type)
+      dummy_class3 = class_for_search_columns(:name, :type)
 
       expect(dummy_class1).to respond_to(:where_name_contains)
       expect(dummy_class2).to respond_to(:where_type_contains)
@@ -18,38 +19,42 @@ RSpec.describe Searchable do
     end
   end
 
-
   search_columns.each do |search_column|
     describe ".where_#{search_column}_contains" do
-
-      let(:search_string) { 'o' }
       subject { dummy_class.send("where_#{search_column}_contains", search_string) }
 
+      let(:search_string) { "o" }
+
       before do
-        dummy_class.create(name: 'Hallo', data_type: 'json')
-        dummy_class.create(name: 'Hallo2', data_type: 'json')
-        dummy_class.create(name: 'Ciao', data_type: 'html')
-        dummy_class.create(name: 'Tschüss', data_type: 'html')
-        dummy_class.create(name: 'Whatever', data_type: 'html')
+        dummy_class.create(name: "Hallo", data_type: "json")
+        dummy_class.create(name: "Hallo2", data_type: "json")
+        dummy_class.create(name: "Ciao", data_type: "html")
+        dummy_class.create(name: "Tschüss", data_type: "html")
+        dummy_class.create(name: "Whatever", data_type: "html")
       end
 
-      context 'without search_string given' do
-        let(:search_string) { '' }
+      context "without search_string given" do
+        let(:search_string) { "" }
+
         it { is_expected.to eq(dummy_class.all) }
       end
 
-      context 'without search_string given' do
-        let(:search_string) { 'o' }
-        it { is_expected.to eq(dummy_class.where("#{search_column} LIKE '%#{search_string}%'")) }
+      context "with search_string given" do
+        it do
+          if search_column == :name
+            expect(subject.count).to eq(3)
+          elsif search_column == :data_type
+            expect(subject.count).to eq(2)
+          end
+        end
       end
-
     end
   end
 end
 
 def class_for_search_columns(*search_columns)
   Class.new(ActiveRecord::Base) do
-    self.table_name = 'static_contents'
+    self.table_name = "static_contents"
 
     include Searchable
     searchable_on *search_columns

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Searchable do
+
+  search_columns = [:data_type, :name]
+  let(:dummy_class) { class_for_search_columns(*search_columns) }
+
+  context "with searchable_on called" do
+    it "should add searching class methods for specified search_columns" do
+      dummy_class1 = class_for_search_columns(:name) 
+      dummy_class2 = class_for_search_columns(:type) 
+      dummy_class3 = class_for_search_columns(:name, :type) 
+
+      expect(dummy_class1).to respond_to(:where_name_contains)
+      expect(dummy_class2).to respond_to(:where_type_contains)
+      expect(dummy_class3).to respond_to(:where_name_contains)
+      expect(dummy_class3).to respond_to(:where_type_contains)
+    end
+  end
+
+
+  search_columns.each do |search_column|
+    describe ".where_#{search_column}_contains" do
+
+      let(:search_string) { 'o' }
+      subject { dummy_class.send("where_#{search_column}_contains", search_string) }
+
+      before do
+        dummy_class.create(name: 'Hallo', data_type: 'json')
+        dummy_class.create(name: 'Hallo2', data_type: 'json')
+        dummy_class.create(name: 'Ciao', data_type: 'html')
+        dummy_class.create(name: 'Tschüss', data_type: 'html')
+        dummy_class.create(name: 'Whatever', data_type: 'html')
+      end
+
+      context 'without search_string given' do
+        let(:search_string) { '' }
+        it { is_expected.to eq(dummy_class.all) }
+      end
+
+      context 'without search_string given' do
+        let(:search_string) { 'o' }
+        it { is_expected.to eq(dummy_class.where("#{search_column} LIKE '%#{search_string}%'")) }
+      end
+
+    end
+  end
+end
+
+def class_for_search_columns(*search_columns)
+  Class.new(ActiveRecord::Base) do
+    self.table_name = 'static_contents'
+
+    include Searchable
+    searchable_on *search_columns
+  end
+end


### PR DESCRIPTION

<img width="933" alt="Screenshot 2021-12-31 at 13 00 39" src="https://user-images.githubusercontent.com/3327396/147822310-e41e8043-06b7-490f-adcf-145ac98d95f1.png">

Provide search functionality in the admin interface.

Originally I wanted to use a gem for this, but I didn't find one that matched my (super simple) needs:
- [ransack](https://github.com/activerecord-hackery/ransack) is far too complex for what we want to do
- [minidusen](https://github.com/makandra/minidusen) seems to do what we want, but the API is ugly
- [textacular](https://github.com/textacular/textacular) looked perfect, but it only supports postgres

So, once again, I wrote my own concern, `Searchable`. It's awfully simple and essentially only adds syntactic sugar for `'WHERE column LIKE %str%'`. Could have just written the SQL to the controllers tbh, but I only realised halfway through that what I want to do is THIS simple.
And also, I don't like sql inside of controllers.

Opinions?