### PR TITLE
hotfix: pagination for accounts

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -18,6 +18,7 @@ class AccountsController < ApplicationController
     @users = User
       .sorted_for_params(params)
       .where_email_contains(params[:query])
+      .page(params[:page])
   end
 
   def edit


### PR DESCRIPTION
- added missing relation to kaminari so visiting the index page resulted in an error with `undefined method 'total_pages'`

SVA-397