### PR TITLE
fix(roles): add missing filter scope for surveys and static contents

### DIFF
--- a/app/graphql/mutations/create_or_update_static_content.rb
+++ b/app/graphql/mutations/create_or_update_static_content.rb
@@ -26,8 +26,9 @@ module Mutations
         static_content_id = params.delete(:id)
 
         if static_content_id.present?
-          static_content = StaticContent.find(static_content_id)
-          static_content.update(params)
+          static_content = StaticContent.filtered_for_current_user(context[:current_user])
+                             .find_by(id: static_content_id)
+          static_content&.update(params)
         else
           static_content = StaticContent.create(params)
         end
@@ -36,6 +37,8 @@ module Mutations
       end
 
       def resource_or_error_message(record)
+        return {} if record.blank?
+
         if record.valid?
           record
         else

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class StaticContent < ApplicationRecord
-  # we need the scope for destroying records, but we do not have any specifics
-  # for current users at static contents, so we return `all`
-  scope :filtered_for_current_user, lambda { |_current_user|
-    all
+  # we need the scope for destroying records, which only admins and editors are allowed to
+  scope :filtered_for_current_user, lambda { |current_user|
+    return all if current_user.admin_role?
+    return all if current_user.editor_role?
+
+    none
   }
 
   attr_accessor :force_create

--- a/app/models/survey/poll.rb
+++ b/app/models/survey/poll.rb
@@ -44,9 +44,9 @@ class Survey::Poll < ApplicationRecord
     )
 
     survey_poll_ids = without_times.pluck(:id) +
-                      without_end_time.map(&:dateable).map(&:id) +
-                      without_start_time.map(&:dateable).map(&:id) +
-                      with_times.map(&:dateable).map(&:id)
+                      without_end_time.map(&:dateable).compact.map(&:id) +
+                      without_start_time.map(&:dateable).compact.map(&:id) +
+                      with_times.map(&:dateable).compact.map(&:id)
 
     where(id: survey_poll_ids.uniq)
   }


### PR DESCRIPTION
- added `filtered_for_current_user` when creating or updating surveys and static contents to respect roles entirely
- added `compact` on retrieving `survey_poll_ids` to avoid crashes when `dateable` map returns an array with `nil`s
- updated scope for static contents to restrict abilities just for admins and editors

SVA-388