### PR TITLE
[SVA-308] Add exclude filter for newsItemsDataProviders query

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -52,7 +52,7 @@ class Resolvers::EventRecordsSearch
   end
 
   def apply_category_id(scope, value)
-    scope.with_category(value)
+    scope.by_category(value)
   end
 
   def apply_skip(scope, value)

--- a/app/graphql/resolvers/generic_item_search.rb
+++ b/app/graphql/resolvers/generic_item_search.rb
@@ -98,7 +98,7 @@ class Resolvers::GenericItemSearch
   end
 
   def apply_category_id(scope, value)
-    scope.with_category(value)
+    scope.by_category(value)
   end
 
   def apply_generic_type(scope, value)

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -27,6 +27,7 @@ class Resolvers::NewsItemsSearch
   option :order, type: NewsItemsOrder, default: "publishedAt_DESC"
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
+  option :excludeDataProviderIds, type: types[types.ID], with: :apply_exclude_data_provider_ids
   option :categoryId, type: types.ID, with: :apply_category_id
 
   def apply_limit(scope, value)
@@ -50,7 +51,11 @@ class Resolvers::NewsItemsSearch
   end
 
   def apply_data_provider_id(scope, value)
-    scope.joins(:data_provider).where(data_providers: { id: value })
+    scope.where(data_provider_id: value)
+  end
+
+  def apply_exclude_data_provider_ids(scope, value)
+    scope.where.not(data_provider_id: value)
   end
 
   def apply_category_id(scope, value)

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -59,7 +59,7 @@ class Resolvers::NewsItemsSearch
   end
 
   def apply_category_id(scope, value)
-    scope.with_category(value)
+    scope.by_category(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -60,7 +60,7 @@ class Resolvers::PointsOfInterestSearch
   end
 
   def apply_category_id(scope, value)
-    scope.with_category(value)
+    scope.by_category(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -60,7 +60,7 @@ class Resolvers::ToursSearch
   end
 
   def apply_category_id(scope, value)
-    scope.with_category(value)
+    scope.by_category(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -118,7 +118,11 @@ module Types
     def news_items_data_providers(category_id: nil)
       return DataProvider.joins(:news_items).order(:name).uniq if category_id.blank?
 
-      NewsItem.with_category(category_id).includes(:data_provider).map(&:data_provider).sort_by do |data_provider|
+      NewsItem
+        .with_category(category_id)
+        .includes(:data_provider)
+        .map(&:data_provider)
+        .sort_by do |data_provider|
         data_provider.name.downcase
       end.uniq
     end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -119,7 +119,7 @@ module Types
       return DataProvider.joins(:news_items).order(:name).uniq if category_id.blank?
 
       NewsItem
-        .with_category(category_id)
+        .by_category(category_id)
         .includes(:data_provider)
         .map(&:data_provider)
         .sort_by do |data_provider|

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -118,7 +118,7 @@ module Types
     def news_items_data_providers(category_id: nil)
       return DataProvider.joins(:news_items).order(:name).uniq if category_id.blank?
 
-      NewsItem.with_category(category_id).map(&:data_provider).sort_by do |data_provider|
+      NewsItem.with_category(category_id).includes(:data_provider).map(&:data_provider).sort_by do |data_provider|
         data_provider.name.downcase
       end.uniq
     end

--- a/app/models/data_resources/attraction.rb
+++ b/app/models/data_resources/attraction.rb
@@ -23,7 +23,7 @@ class Attraction < ApplicationRecord
 
   scope :visible, -> { where(visible: true) }
 
-  scope :with_category, lambda { |category_id|
+  scope :by_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)
   }
 

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -70,7 +70,7 @@ class EventRecord < ApplicationRecord
     where(id: upcoming_event_record_ids)
   }
 
-  scope :with_category, lambda { |category_id|
+  scope :by_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)
   }
 

--- a/app/models/data_resources/generic_item.rb
+++ b/app/models/data_resources/generic_item.rb
@@ -30,7 +30,7 @@ class GenericItem < ApplicationRecord
   # defined by FilterByRole
   # scope :visible, -> { where(visible: true) }
 
-  scope :with_category, lambda { |category_id|
+  scope :by_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)
   }
 

--- a/app/models/data_resources/news_item.rb
+++ b/app/models/data_resources/news_item.rb
@@ -22,7 +22,7 @@ class NewsItem < ApplicationRecord
   has_many :categories, through: :data_resource_categories
   has_many :content_blocks, as: :content_blockable, dependent: :destroy
 
-  scope :with_category, lambda { |category_id|
+  scope :by_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)
   }
 


### PR DESCRIPTION
Added possibility to filter `DataProvider` in `newsItemDataProviders` query with `exclude` parameter

SVA-308


**New query example:**

```graphql
query NewsItems($ids: [ID!]) {
  newsItems(excludeDataProviderIds: $ids) {
    id
    contentBlocks {
      title
    }
    dataProvider {
      id
    }
  }
}
```

Example variables:
```graphql
{
  "ids": [
    1,
    3,
    5
  ]
}
```