### PR TITLE
feat: create and edit versioned static content

### DIFF
--- a/app/graphql/mutations/create_or_update_static_content.rb
+++ b/app/graphql/mutations/create_or_update_static_content.rb
@@ -7,6 +7,7 @@ module Mutations
     argument :name, String, required: false
     argument :content, String, required: false
     argument :data_type, String, required: true
+    argument :version, String, required: false
 
     field :static_content, Types::QueryTypes::PublicHtmlFileType, null: true
 

--- a/app/graphql/types/query_types/public_html_file_type.rb
+++ b/app/graphql/types/query_types/public_html_file_type.rb
@@ -6,6 +6,7 @@ module Types
     field :name, String, null: true
     field :content, String, null: true
     field :data_type, String, null: true
+    field :version, String, null: true
     field :updated_at, String, null: true
     field :created_at, String, null: true
   end

--- a/app/graphql/types/query_types/public_json_file_type.rb
+++ b/app/graphql/types/query_types/public_json_file_type.rb
@@ -6,6 +6,7 @@ module Types
     field :name, String, null: false
     field :content, GraphQL::Types::JSON, null: false
     field :data_type, String, null: true
+    field :version, String, null: true
     field :updated_at, String, null: true
     field :created_at, String, null: true
   end

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -40,4 +40,5 @@ end
 #  content    :text(65535)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  version    :string(255)
 #

--- a/app/views/static_contents/_static_content.json.jbuilder
+++ b/app/views/static_contents/_static_content.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! static_content, :id, :name, :data_type, :content, :created_at, :updated_at
+json.extract! static_content, :id, :name, :data_type, :content, :version, :created_at, :updated_at
 json.url static_content_url(static_content, format: :json)

--- a/public/schema.graphql
+++ b/public/schema.graphql
@@ -383,7 +383,7 @@ type Mutation {
   createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
   createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, forceCreate: Boolean, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
   createNewsItem(address: AddressInput, author: String, categories: [CategoryInput!], categoryName: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], externalId: String, forceCreate: Boolean, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, pushNotification: Boolean, showPublishDate: Boolean, sourceUrl: WebUrlInput, title: String): NewsItem!
-  createOrUpdateStaticContent(content: String, dataType: String!, forceCreate: Boolean, id: ID, name: String): PublicHtmlFile!
+  createOrUpdateStaticContent(content: String, dataType: String!, forceCreate: Boolean, id: ID, name: String, version: String): PublicHtmlFile!
   createOrUpdateSurveyPoll(canComment: Boolean, date: DateInput, description: I18nJSON, forceCreate: Boolean, id: ID, isMultilingual: Boolean, questionAllowMultipleResponses: I18nJSON, questionId: ID, questionTitle: I18nJSON!, responseOptions: [JSON!]!, title: I18nJSON): SurveyPoll!
   createPointOfInterest(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, location: LocationInput, lunches: [LunchInput!], mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, openingHours: [OpeningHourInput!], operatingCompany: OperatingCompanyInput, priceInformations: [PriceInput!], tags: [String!], webUrls: [WebUrlInput!]): PointOfInterest!
   createTour(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, geometryTourData: [GeoLocationInput!], lengthKm: Int!, location: LocationInput, meansOfTransportation: String, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, operatingCompany: OperatingCompanyInput, tags: [String!], webUrls: [WebUrlInput!]): Tour!
@@ -563,6 +563,7 @@ type PublicHtmlFile {
   id: ID
   name: String
   updatedAt: String
+  version: String
 }
 
 type PublicJsonFile {
@@ -572,6 +573,7 @@ type PublicJsonFile {
   id: ID
   name: String!
   updatedAt: String
+  version: String
 }
 
 type Query {

--- a/public/schema.json
+++ b/public/schema.json
@@ -6593,6 +6593,20 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -6687,6 +6701,20 @@
             },
             {
               "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
               "description": null,
               "args": [
 
@@ -8215,6 +8243,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -383,7 +383,7 @@ type Mutation {
   createEventRecord(accessibilityInformation: AccessibilityInformationInput, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, contacts: [ContactInput!], dates: [DateInput!], description: String, externalId: String, forceCreate: Boolean, location: LocationInput, mediaContents: [MediaContentInput!], organizer: OperatingCompanyInput, parentId: Int, priceInformations: [PriceInput!], region: RegionInput, regionName: String, repeat: Boolean, repeatDuration: RepeatDurationInput, tags: [String!], title: String, urls: [WebUrlInput!]): EventRecord!
   createGenericItem(accessibilityInformations: [AccessibilityInformationInput!], addresses: [AddressInput!], author: String, categories: [CategoryInput!], categoryName: String, companies: [OperatingCompanyInput!], contacts: [ContactInput!], contentBlocks: [ContentBlockInput!], dates: [DateInput!], externalId: String, forceCreate: Boolean, genericItems: [GenericItemInput!], genericType: String, locations: [LocationInput!], mediaContents: [MediaContentInput!], openingHours: [OpeningHourInput!], payload: JSON, priceInformations: [PriceInput!], publicationDate: String, publishedAt: String, pushNotification: Boolean, title: String, webUrls: [WebUrlInput!]): GenericItem!
   createNewsItem(address: AddressInput, author: String, categories: [CategoryInput!], categoryName: String, charactersToBeShown: Int, contentBlocks: [ContentBlockInput!], externalId: String, forceCreate: Boolean, fullVersion: Boolean, newsType: String, publicationDate: String, publishedAt: String, pushNotification: Boolean, showPublishDate: Boolean, sourceUrl: WebUrlInput, title: String): NewsItem!
-  createOrUpdateStaticContent(content: String, dataType: String!, forceCreate: Boolean, id: ID, name: String): PublicHtmlFile!
+  createOrUpdateStaticContent(content: String, dataType: String!, forceCreate: Boolean, id: ID, name: String, version: String): PublicHtmlFile!
   createOrUpdateSurveyPoll(canComment: Boolean, date: DateInput, description: I18nJSON, forceCreate: Boolean, id: ID, isMultilingual: Boolean, questionAllowMultipleResponses: I18nJSON, questionId: ID, questionTitle: I18nJSON!, responseOptions: [JSON!]!, title: I18nJSON): SurveyPoll!
   createPointOfInterest(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, location: LocationInput, lunches: [LunchInput!], mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, openingHours: [OpeningHourInput!], operatingCompany: OperatingCompanyInput, priceInformations: [PriceInput!], tags: [String!], webUrls: [WebUrlInput!]): PointOfInterest!
   createTour(accessibilityInformation: AccessibilityInformationInput, active: Boolean, addresses: [AddressInput!], categories: [CategoryInput!], categoryName: String, certificates: [CertificateInput!], contact: ContactInput, description: String, forceCreate: Boolean, geometryTourData: [GeoLocationInput!], lengthKm: Int!, location: LocationInput, meansOfTransportation: String, mediaContents: [MediaContentInput!], mobileDescription: String, name: String!, operatingCompany: OperatingCompanyInput, tags: [String!], webUrls: [WebUrlInput!]): Tour!
@@ -563,6 +563,7 @@ type PublicHtmlFile {
   id: ID
   name: String
   updatedAt: String
+  version: String
 }
 
 type PublicJsonFile {
@@ -572,6 +573,7 @@ type PublicJsonFile {
   id: ID
   name: String!
   updatedAt: String
+  version: String
 }
 
 type Query {

--- a/schema.json
+++ b/schema.json
@@ -6593,6 +6593,20 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -6687,6 +6701,20 @@
             },
             {
               "name": "updatedAt",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
               "description": null,
               "args": [
 
@@ -8215,6 +8243,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }

--- a/spec/factories/static_contents.rb
+++ b/spec/factories/static_contents.rb
@@ -16,4 +16,5 @@ end
 #  content    :text(65535)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  version    :string(255)
 #

--- a/spec/graphql/mutations/create_or_update_static_content_spec.rb
+++ b/spec/graphql/mutations/create_or_update_static_content_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe Mutations::CreateOrUpdateStaticContent do
       expect(new_static_content.message).to eq("Invalid input: Name has already been taken")
     end
 
+    it "creates a new and valid static content with same name and new version" do
+      static_content
+      new_static_content = perform(
+        name: "asd",
+        content: "<p>bbb asd dasd asdwewe</p>",
+        version: "1.0.0",
+        data_type: "html"
+      )
+
+      expect(new_static_content).to be_a(StaticContent)
+      expect(new_static_content).to be_valid
+    end
+
     it "fails creating without data type" do
       static_content
       new_static_content = perform(

--- a/spec/models/static_content_spec.rb
+++ b/spec/models/static_content_spec.rb
@@ -85,4 +85,5 @@ end
 #  content    :text(65535)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  version    :string(255)
 #


### PR DESCRIPTION
- took `version` into account for static contents
- updated graphql schema

SVA-315