### PR TITLE
feat: add option to resolve attractions by location

### DIFF
--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -30,6 +30,7 @@ class Resolvers::PointsOfInterestSearch
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
   option :categoryId, type: types.ID, with: :apply_category_id
+  option :location, type: types.String, with: :apply_location
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -61,6 +62,10 @@ class Resolvers::PointsOfInterestSearch
 
   def apply_category_id(scope, value)
     scope.by_category(value)
+  end
+
+  def apply_location(scope, value)
+    scope.by_location(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -30,6 +30,7 @@ class Resolvers::ToursSearch
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
   option :categoryId, type: types.ID, with: :apply_category_id
+  option :location, type: types.String, with: :apply_location
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -61,6 +62,10 @@ class Resolvers::ToursSearch
 
   def apply_category_id(scope, value)
     scope.by_category(value)
+  end
+
+  def apply_location(scope, value)
+    scope.by_location(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/types/query_types/tour_type.rb
+++ b/app/graphql/types/query_types/tour_type.rb
@@ -14,6 +14,7 @@ module Types
     field :length_km, Integer, null: true
     field :category, QueryTypes::CategoryType, null: true
     field :categories, [QueryTypes::CategoryType], null: true
+    field :location, QueryTypes::LocationType, null: true
     field :data_provider, QueryTypes::DataProviderType, null: true
     field :tags, String, null: true
     field :contact, QueryTypes::ContactType, null: true

--- a/app/models/data_resources/attraction.rb
+++ b/app/models/data_resources/attraction.rb
@@ -20,11 +20,16 @@ class Attraction < ApplicationRecord
   has_one :operating_company, as: :companyable, dependent: :destroy
   has_many :web_urls, as: :web_urlable, dependent: :destroy
   has_one :external_reference, as: :external, dependent: :destroy
+  has_one :location, as: :locateable, dependent: :destroy
 
   scope :visible, -> { where(visible: true) }
 
   scope :by_category, lambda { |category_id|
     where(categories: { id: category_id }).joins(:categories)
+  }
+
+  scope :by_location, lambda { |location_name|
+    where(locations: { name: location_name }).joins(:location)
   }
 
   validates_presence_of :name
@@ -34,7 +39,7 @@ class Attraction < ApplicationRecord
   accepts_nested_attributes_for :addresses, :contact, :media_contents,
                                 :accessibility_information, :operating_company,
                                 :data_provider, :certificates,
-                                :regions
+                                :regions, :location
 
   # Sicherstellung der Abwärtskompatibilität seit 09/2020
   def category

--- a/app/models/data_resources/point_of_interest.rb
+++ b/app/models/data_resources/point_of_interest.rb
@@ -15,10 +15,9 @@ class PointOfInterest < Attraction
   has_many :categories, through: :data_resource_categories
   has_many :opening_hours, as: :openingable, dependent: :destroy
   has_many :price_informations, as: :priceable, class_name: "Price", dependent: :destroy
-  has_one :location, as: :locateable, dependent: :destroy
   has_many :lunches, dependent: :destroy
 
-  accepts_nested_attributes_for :price_informations, :opening_hours, :location, :lunches
+  accepts_nested_attributes_for :price_informations, :opening_hours, :lunches
 
   def unique_id
     fields = [name, type]

--- a/app/models/data_resources/tour.rb
+++ b/app/models/data_resources/tour.rb
@@ -15,9 +15,8 @@ class Tour < Attraction
   has_many :data_resource_categories, -> { where(data_resource_type: "Tour") }, foreign_key: :data_resource_id
   has_many :categories, through: :data_resource_categories
   has_many :geometry_tour_data, as: :geo_locateable, class_name: "GeoLocation", dependent: :destroy
-  has_one :location, as: :locateable, dependent: :destroy
 
-  accepts_nested_attributes_for :geometry_tour_data, :location
+  accepts_nested_attributes_for :geometry_tour_data
 
   def unique_id
     fields = [name, type]


### PR DESCRIPTION
- refactored `location` association from point of interest
  and tour to `attraction`, because both have it
- added `by_location` scope to filter for a given location name
- applied new option in graphql search resolvers for
  points of interest and tours
  - therefore tour type got the location field, which was missing

SVA-367

---

<img width="1239" alt="Bildschirmfoto 2022-02-04 um 14 50 36" src="https://user-images.githubusercontent.com/1942953/152540039-d4df9235-78c0-4474-801d-5db727fc1147.png">

<img width="1146" alt="Bildschirmfoto 2022-02-04 um 14 49 50" src="https://user-images.githubusercontent.com/1942953/152539907-9fe5b4a3-00f7-4704-bd13-aa587b02bdd6.png">