### PR TITLE
feat(category): respect ancestry in graphql queries

### DIFF
--- a/app/graphql/types/query_types/category_type.rb
+++ b/app/graphql/types/query_types/category_type.rb
@@ -4,16 +4,20 @@ module Types
   class QueryTypes::CategoryType < Types::BaseObject
     field :id, ID, null: true
     field :name, String, null: true
-    field :generic_items_count, Integer, null: true
-    field :points_of_interest_count, Integer, null: true
-    field :tours_count, Integer, null: true
-    field :news_items_count, Integer, null: true
+    field :parent, QueryTypes::CategoryType, null: true
+    field :children, [QueryTypes::CategoryType], null: true
+
     field :event_records_count, Integer, null: true
-    field :upcoming_event_records_count, Integer, null: true
     field :event_records, [QueryTypes::EventRecordType], null: true
-    field :upcoming_event_records, [QueryTypes::EventRecordType], null: true
-    field :points_of_interest, [QueryTypes::PointOfInterestType], null: true
-    field :tours, [QueryTypes::TourType], null: true
+    field :generic_items_count, Integer, null: true
+    field :generic_items, [QueryTypes::GenericItemType], null: true
+    field :news_items_count, Integer, null: true
     field :news_items, [QueryTypes::NewsItemType], null: true
+    field :points_of_interest_count, Integer, null: true
+    field :points_of_interest, [QueryTypes::PointOfInterestType], null: true
+    field :tours_count, Integer, null: true
+    field :tours, [QueryTypes::TourType], null: true
+    field :upcoming_event_records_count, Integer, null: true
+    field :upcoming_event_records, [QueryTypes::EventRecordType], null: true
   end
 end


### PR DESCRIPTION
- sorted fields for better overview
- added missing field for `generic_items` as for the other
  fields with `count`s
- added fields for ancestry methods `parent` and `children`
  to be able to traverse through categories per graphql

SVA-28

---

<img width="793" alt="Bildschirmfoto 2022-02-08 um 12 51 19" src="https://user-images.githubusercontent.com/1942953/152981633-76ad0157-0903-4b7c-97c7-16e93d17e4b8.png">