### PR TITLE
feat: add ability to query POIs and Tours with `categoryIds`

### DIFF
--- a/app/graphql/resolvers/points_of_interest_search.rb
+++ b/app/graphql/resolvers/points_of_interest_search.rb
@@ -30,6 +30,7 @@ class Resolvers::PointsOfInterestSearch
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
   option :categoryId, type: types.ID, with: :apply_category_id
+  option :categoryIds, type: types[types.ID], with: :apply_category_ids
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -62,6 +63,7 @@ class Resolvers::PointsOfInterestSearch
   def apply_category_id(scope, value)
     scope.by_category(value)
   end
+  alias_method :apply_category_ids, :apply_category_id
 
   def apply_order_with_created_at_desc(scope)
     scope.order("created_at DESC")

--- a/app/graphql/resolvers/tours_search.rb
+++ b/app/graphql/resolvers/tours_search.rb
@@ -30,6 +30,7 @@ class Resolvers::ToursSearch
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :category, type: types.String, with: :apply_category
   option :categoryId, type: types.ID, with: :apply_category_id
+  option :categoryIds, type: types[types.ID], with: :apply_category_ids
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -62,6 +63,7 @@ class Resolvers::ToursSearch
   def apply_category_id(scope, value)
     scope.by_category(value)
   end
+  alias_method :apply_category_ids, :apply_category_id
 
   def apply_order_with_created_at_desc(scope)
     scope.order("created_at DESC")


### PR DESCRIPTION
- added option to query for multiple category ids
- updated graphql schema

SVA-475

---

this makes it possible to pass `"categoryIds": [3,4]`. `"categoryIds": 3` also works with the plural key, but the singular `"categoryId"` key is kept for backwards compatibility, as that feature was introduced in past november.