### PR TITLE
fix(static content): save version

### DIFF
--- a/app/controllers/static_contents_controller.rb
+++ b/app/controllers/static_contents_controller.rb
@@ -99,7 +99,7 @@ class StaticContentsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def static_content_params
-      params.require(:static_content).permit(:name, :data_type, :content)
+      params.require(:static_content).permit(:name, :version, :data_type, :content)
     end
 
 end

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -16,6 +16,8 @@ class StaticContent < ApplicationRecord
 
   scope :filter_by_type, ->(type) { where data_type: type }
 
+  before_validation :enforce_nil_for_empty_version
+
   include Sortable
   sortable_on :name, :id
 
@@ -28,6 +30,12 @@ class StaticContent < ApplicationRecord
 
     sorted_results
   end
+
+  private
+
+    def enforce_nil_for_empty_version
+      self.version = nil if version.empty?
+    end
 end
 
 # == Schema Information


### PR DESCRIPTION
- added `:version` in controller to permit its value
- added `enforce_nil_for_empty_version` callback
  to ensure `nil` instead of empty strings after editing
  in order to satisfy validation scope for `:version`
  - until now `nil` and empty string were not handled as
    same value thus the validation failed