### PR TITLE
fix(waste calendar): adjust time zone for delayed jobs

### DIFF
--- a/app/models/data_resources/waste/device_registration.rb
+++ b/app/models/data_resources/waste/device_registration.rb
@@ -4,7 +4,7 @@ class Waste::DeviceRegistration < ApplicationRecord
   def notify_at_time
     return nil if notify_at.blank?
 
-    notify_at.to_s(:time)
+    notify_at.localtime.to_s(:time)
   end
 end
 


### PR DESCRIPTION
- `notify_at_time` is used to set the runner time for delayed jobs to send notifications
  - therefore we need to adjust the time zone because we save UTC in the database

SVA-467