### PR TITLE
feat: categories by location through attractions

### DIFF
--- a/app/graphql/resolvers/categories_search.rb
+++ b/app/graphql/resolvers/categories_search.rb
@@ -25,6 +25,7 @@ class Resolvers::CategoriesSearch
   option :skip, type: types.Int, with: :apply_skip
   option :ids, type: types[types.ID], with: :apply_ids
   option :order, type: CategoriesOrder, default: "name_ASC"
+  option :location, type: types.String, with: :apply_location
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -40,6 +41,10 @@ class Resolvers::CategoriesSearch
 
   def apply_order(scope, value)
     scope.order(value)
+  end
+
+  def apply_location(scope, _value)
+    scope
   end
 
   def apply_order_with_name_desc(scope)

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -32,6 +32,7 @@ class Resolvers::EventRecordsSearch
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :take, type: types.Int, with: :apply_take
+  option :location, type: types.String, with: :apply_location
 
   # :values is array of 2 dates:
   # - first element is :start_date
@@ -80,6 +81,10 @@ class Resolvers::EventRecordsSearch
 
   def apply_data_provider_id(scope, value)
     scope.joins(:data_provider).where(data_providers: { id: value })
+  end
+
+  def apply_location(scope, value)
+    scope.by_location(value)
   end
 
   def apply_order_with_created_at_desc(scope)

--- a/app/graphql/resolvers/generic_item_search.rb
+++ b/app/graphql/resolvers/generic_item_search.rb
@@ -32,6 +32,7 @@ class Resolvers::GenericItemSearch
   option :limit, type: types.Int, with: :apply_limit
   option :order, type: GenericItemOrder, default: "createdAt_DESC"
   option :skip, type: types.Int, with: :apply_skip
+  option :location, type: types.String, with: :apply_location
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -107,6 +108,10 @@ class Resolvers::GenericItemSearch
 
   def apply_external_id(scope, value)
     scope.where(external_id: value)
+  end
+
+  def apply_location(scope, value)
+    scope.by_location(value)
   end
 
   # https://github.com/nettofarah/graphql-query-resolver

--- a/app/graphql/types/query_types/category_type.rb
+++ b/app/graphql/types/query_types/category_type.rb
@@ -7,17 +7,141 @@ module Types
     field :parent, QueryTypes::CategoryType, null: true
     field :children, [QueryTypes::CategoryType], null: true
 
-    field :event_records_count, Integer, null: true
-    field :event_records, [QueryTypes::EventRecordType], null: true
-    field :generic_items_count, Integer, null: true
-    field :generic_items, [QueryTypes::GenericItemType], null: true
+    field :event_records_count,
+          Integer,
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            event_records = if location
+                              category.event_records.by_location(location)
+                            else
+                              category.event_records
+                            end
+
+            event_records.visible.count
+          }
+    field :event_records,
+          [QueryTypes::EventRecordType],
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            if location
+              category.event_records.by_location(location)
+            else
+              category.event_records
+            end
+          }
+    field :generic_items_count,
+          Integer,
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            generic_items = if location
+                              category.generic_items.by_location(location)
+                            else
+                              category.generic_items
+                            end
+
+            generic_items.visible.count
+          }
+    field :generic_items,
+          [QueryTypes::GenericItemType],
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            if location
+              category.generic_items.by_location(location)
+            else
+              category.generic_items
+            end
+          }
+
     field :news_items_count, Integer, null: true
     field :news_items, [QueryTypes::NewsItemType], null: true
-    field :points_of_interest_count, Integer, null: true
-    field :points_of_interest, [QueryTypes::PointOfInterestType], null: true
-    field :tours_count, Integer, null: true
-    field :tours, [QueryTypes::TourType], null: true
-    field :upcoming_event_records_count, Integer, null: true
-    field :upcoming_event_records, [QueryTypes::EventRecordType], null: true
+
+    field :points_of_interest_count,
+          Integer,
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            points_of_interest = if location
+                                   category.points_of_interest.by_location(location)
+                                 else
+                                   category.points_of_interest
+                                 end
+
+            points_of_interest.visible.count
+          }
+    field :points_of_interest,
+          [QueryTypes::PointOfInterestType],
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            if location
+              category.points_of_interest.by_location(location)
+            else
+              category.points_of_interest
+            end
+          }
+
+    field :tours_count,
+          Integer,
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            tours = if location
+                      category.tours.by_location(location)
+                    else
+                      category.tours
+                    end
+
+            tours.visible.count
+          }
+    field :tours,
+          [QueryTypes::TourType],
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            if location
+              category.tours.by_location(location)
+            else
+              category.tours
+            end
+          }
+
+    field :upcoming_event_records_count,
+          Integer,
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            upcoming_event_records = if location
+                                       category.upcoming_event_records.by_location(location)
+                                     else
+                                       category.upcoming_event_records
+                                     end
+
+            upcoming_event_records.visible.count
+          }
+    field :upcoming_event_records,
+          [QueryTypes::EventRecordType],
+          null: true,
+          resolve: lambda { |category, _args, ctx|
+            location = ctx.irep_node.parent.arguments.location
+
+            if location
+              category.upcoming_event_records.by_location(location)
+            else
+              category.upcoming_event_records
+            end
+          }
   end
 end

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -74,6 +74,11 @@ class EventRecord < ApplicationRecord
     where(categories: { id: category_id }).joins(:categories)
   }
 
+  scope :by_location, lambda { |location_name|
+    where(locations: { name: location_name }).or(where(addresses: { city: location_name }))
+      .left_joins(:location).left_joins(:addresses)
+  }
+
   accepts_nested_attributes_for :urls, reject_if: ->(attr) { attr[:url].blank? }
   accepts_nested_attributes_for :data_provider, :organizer,
                                 :addresses, :location, :contacts,

--- a/app/models/data_resources/generic_item.rb
+++ b/app/models/data_resources/generic_item.rb
@@ -34,6 +34,11 @@ class GenericItem < ApplicationRecord
     where(categories: { id: category_id }).joins(:categories)
   }
 
+  scope :by_location, lambda { |location_name|
+    where(locations: { name: location_name }).or(where(addresses: { city: location_name }))
+      .left_joins(:locations).left_joins(:addresses)
+  }
+
   accepts_nested_attributes_for :web_urls, reject_if: ->(attr) { attr[:url].blank? }
   accepts_nested_attributes_for :content_blocks, :data_provider, :price_informations, :opening_hours,
                                 :media_contents, :accessibility_informations, :addresses, :contacts,


### PR DESCRIPTION
feat(graphql): add location scopes for event records and generic items 

- implemented possibility to query for event records and generic items
  with location filter, which was already possible for points of interest
  and tours

feat(graphql): filter results of categories query by location

- added a new option `location` which just returns the `scope`
  but is needed to allow the parameter being used in category
  type fields
- added resolver to each field types that can have location filter
  with logic to get a possibly given location from arguments and
  use it to scope the results if present

SVA-475