### PR TITLE
fix: add missing auth before action to /categories

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,7 +3,14 @@
 class CategoriesController < ApplicationController
   layout "doorkeeper/admin"
 
+  before_action :authenticate_user!
+  before_action :authenticate_admin
+
   before_action :set_category, only: [:show, :edit, :update, :destroy]
+
+  def authenticate_admin
+    render inline: "not allowed", status: 404 unless current_user.admin_role?
+  end
 
   # GET /categories
   # GET /categories.json


### PR DESCRIPTION
- if not logged in the /categories route returned a 500, because admin stuff was not checked
- copied actions and method from `AppUserContentsController`