### PR TITLE
fix(static content): nil version

### DIFF
--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -34,7 +34,7 @@ class StaticContent < ApplicationRecord
   private
 
     def enforce_nil_for_empty_version
-      self.version = nil if version.empty?
+      self.version = nil if version.blank?
     end
 end
 


### PR DESCRIPTION
- changed check in `enforce_nil_for_empty_version` from
  `.empty?` to `.blank?` to catch cases, where `version` is
  already `nil`

---

fixes Rollbar `#224 NoMethodError: undefined method 'empty?' for nil:NilClass`