### PR TITLE
Field Definition mit optionalem `Location` Argument

### DIFF
--- a/app/graphql/types/query_types/category_type.rb
+++ b/app/graphql/types/query_types/category_type.rb
@@ -7,29 +7,33 @@ module Types
     field :parent, QueryTypes::CategoryType, null: true
     field :children, [QueryTypes::CategoryType], null: true
 
+    field :news_items_count, Integer, null: true
+    field :news_items, [QueryTypes::NewsItemType], null: true
+
+    # fields with optional location filter
     field :event_records_count, Integer, null: true, method: :event_records_count_by_location do
       argument :location, String, required: false
     end
-
     field :event_records, [QueryTypes::EventRecordType], null: true, method: :event_records_by_location do
       argument :location, String, required: false
     end
-
-    field :generic_items, [QueryTypes::GenericItemType], null: true, method: :generic_items_by_location do
+    field :upcoming_event_records_count, Integer, null: true, method: :upcoming_event_records_count_by_location do
+      argument :location, String, required: false
+    end
+    field :upcoming_event_records, [QueryTypes::EventRecordType], null: true, method: :upcoming_event_records_by_location do
       argument :location, String, required: false
     end
 
     field :generic_items_count, Integer, null: true, method: :generic_items_count_by_location do
       argument :location, String, required: false
     end
-
-    field :news_items_count, Integer, null: true
-    field :news_items, [QueryTypes::NewsItemType], null: true
+    field :generic_items, [QueryTypes::GenericItemType], null: true, method: :generic_items_by_location do
+      argument :location, String, required: false
+    end
 
     field :points_of_interest_count, Integer, null: true, method: :points_of_interest_count_by_location do
       argument :location, String, required: false
     end
-
     field :points_of_interest, [QueryTypes::PointOfInterestType], null: true, method: :points_of_interest_by_location do
       argument :location, String, required: false
     end
@@ -37,16 +41,7 @@ module Types
     field :tours_count, Integer, null: true, method: :tours_count_by_location do
       argument :location, String, required: false
     end
-
     field :tours, [QueryTypes::TourType], null: true, method: :tours_by_location do
-      argument :location, String, required: false
-    end
-
-    field :upcoming_event_records_count, Integer, null: true, method: :upcoming_event_records_count_by_location do
-      argument :location, String, required: false
-    end
-
-    field :upcoming_event_records, [QueryTypes::EventRecordType], null: true, method: :upcoming_event_records_by_location do
       argument :location, String, required: false
     end
   end

--- a/app/graphql/types/query_types/category_type.rb
+++ b/app/graphql/types/query_types/category_type.rb
@@ -7,141 +7,47 @@ module Types
     field :parent, QueryTypes::CategoryType, null: true
     field :children, [QueryTypes::CategoryType], null: true
 
-    field :event_records_count,
-          Integer,
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
+    field :event_records_count, Integer, null: true, method: :event_records_count_by_location do
+      argument :location, String, required: false
+    end
 
-            event_records = if location
-                              category.event_records.by_location(location)
-                            else
-                              category.event_records
-                            end
+    field :event_records, [QueryTypes::EventRecordType], null: true, method: :event_records_by_location do
+      argument :location, String, required: false
+    end
 
-            event_records.visible.count
-          }
-    field :event_records,
-          [QueryTypes::EventRecordType],
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
+    field :generic_items, [QueryTypes::GenericItemType], null: true, method: :generic_items_by_location do
+      argument :location, String, required: false
+    end
 
-            if location
-              category.event_records.by_location(location)
-            else
-              category.event_records
-            end
-          }
-    field :generic_items_count,
-          Integer,
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
-
-            generic_items = if location
-                              category.generic_items.by_location(location)
-                            else
-                              category.generic_items
-                            end
-
-            generic_items.visible.count
-          }
-    field :generic_items,
-          [QueryTypes::GenericItemType],
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
-
-            if location
-              category.generic_items.by_location(location)
-            else
-              category.generic_items
-            end
-          }
+    field :generic_items_count, Integer, null: true, method: :generic_items_count_by_location do
+      argument :location, String, required: false
+    end
 
     field :news_items_count, Integer, null: true
     field :news_items, [QueryTypes::NewsItemType], null: true
 
-    field :points_of_interest_count,
-          Integer,
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
+    field :points_of_interest_count, Integer, null: true, method: :points_of_interest_count_by_location do
+      argument :location, String, required: false
+    end
 
-            points_of_interest = if location
-                                   category.points_of_interest.by_location(location)
-                                 else
-                                   category.points_of_interest
-                                 end
+    field :points_of_interest, [QueryTypes::PointOfInterestType], null: true, method: :points_of_interest_by_location do
+      argument :location, String, required: false
+    end
 
-            points_of_interest.visible.count
-          }
-    field :points_of_interest,
-          [QueryTypes::PointOfInterestType],
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
+    field :tours_count, Integer, null: true, method: :tours_count_by_location do
+      argument :location, String, required: false
+    end
 
-            if location
-              category.points_of_interest.by_location(location)
-            else
-              category.points_of_interest
-            end
-          }
+    field :tours, [QueryTypes::TourType], null: true, method: :tours_by_location do
+      argument :location, String, required: false
+    end
 
-    field :tours_count,
-          Integer,
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
+    field :upcoming_event_records_count, Integer, null: true, method: :upcoming_event_records_count_by_location do
+      argument :location, String, required: false
+    end
 
-            tours = if location
-                      category.tours.by_location(location)
-                    else
-                      category.tours
-                    end
-
-            tours.visible.count
-          }
-    field :tours,
-          [QueryTypes::TourType],
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
-
-            if location
-              category.tours.by_location(location)
-            else
-              category.tours
-            end
-          }
-
-    field :upcoming_event_records_count,
-          Integer,
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
-
-            upcoming_event_records = if location
-                                       category.upcoming_event_records.by_location(location)
-                                     else
-                                       category.upcoming_event_records
-                                     end
-
-            upcoming_event_records.visible.count
-          }
-    field :upcoming_event_records,
-          [QueryTypes::EventRecordType],
-          null: true,
-          resolve: lambda { |category, _args, ctx|
-            location = ctx.irep_node.parent.arguments.location
-
-            if location
-              category.upcoming_event_records.by_location(location)
-            else
-              category.upcoming_event_records
-            end
-          }
+    field :upcoming_event_records, [QueryTypes::EventRecordType], null: true, method: :upcoming_event_records_by_location do
+      argument :location, String, required: false
+    end
   end
 end

--- a/app/models/data_resources/resource_modules/category.rb
+++ b/app/models/data_resources/resource_modules/category.rb
@@ -15,45 +15,27 @@ class Category < ApplicationRecord
 
   after_destroy :cleanup_data_resource_settings
 
-  def generic_items_count
-    return 0 if generic_items.blank?
-
-    generic_items.visible.count
-  end
-
-  def points_of_interest_count
-    return 0 if points_of_interest.blank?
-
-    points_of_interest.visible.count
-  end
-
-  def tours_count
-    return 0 if tours.blank?
-
-    tours.visible.count
-  end
-
-  def news_items_count
-    return 0 if news_items.blank?
-
-    news_items.visible.count
-  end
-
-  def event_records_count
-    return 0 if event_records.blank?
-
-    event_records.visible.count
-  end
-
   def upcoming_event_records
     event_records.upcoming(nil)
   end
 
-  def upcoming_event_records_count
-    return 0 if event_records.blank?
-    return 0 if upcoming_event_records.blank?
+  # Defines 2 methods for a list of record type:
+  # - Returns the number of items the given location and record type
+  # - Returns the items of the given location and record type
+  [:event_records, :upcoming_event_records, :generic_items, :points_of_interest, :tours].each do |item_source|
+    define_method "#{item_source}_by_location" do |args = nil|
+      return nil if send(item_source).blank?
+      return send(item_source).visible.by_location(args[:location]) if args.present? && args[:location].present?
 
-    upcoming_event_records.count
+      send(item_source).visible
+    end
+
+    define_method "#{item_source}_count_by_location" do |args = nil|
+      items = send("#{item_source}_by_location", args)
+      return 0 if items.blank?
+
+      items.count
+    end
   end
 
   # Wenn eine Kategorie gelöscht wird kann es jedoch sein,

--- a/app/models/data_resources/resource_modules/category.rb
+++ b/app/models/data_resources/resource_modules/category.rb
@@ -15,6 +15,12 @@ class Category < ApplicationRecord
 
   after_destroy :cleanup_data_resource_settings
 
+  def news_items_count
+    return 0 if news_items.blank?
+
+    news_items.visible.count
+  end
+
   def upcoming_event_records
     event_records.upcoming(nil)
   end
@@ -24,7 +30,7 @@ class Category < ApplicationRecord
   # - Returns the items of the given location and record type
   [:event_records, :upcoming_event_records, :generic_items, :points_of_interest, :tours].each do |item_source|
     define_method "#{item_source}_by_location" do |args = nil|
-      return nil if send(item_source).blank?
+      return [] if send(item_source).blank?
       return send(item_source).visible.by_location(args[:location]) if args.present? && args[:location].present?
 
       send(item_source).visible

--- a/app/models/static_content.rb
+++ b/app/models/static_content.rb
@@ -34,7 +34,7 @@ class StaticContent < ApplicationRecord
   private
 
     def enforce_nil_for_empty_version
-      self.version = nil if version.empty?
+      self.version = nil if version.try(:empty?)
     end
 end
 


### PR DESCRIPTION
graphql Calls umgebaut:

```
query { categories{
  name
  genericItemsCount(location: "Hamburg")
  genericItems(location: "Berlin"){title}
  pointsOfInterestCount
  pointsOfInterest{name}
  eventRecordsCount
  toursCount
  tours{name}
  upcomingEventRecordsCount
  upcomingEventRecords{title}
  }
}
```

![Bildschirmfoto 2022-04-27 um 15 05 11](https://user-images.githubusercontent.com/90779/165524692-8109590f-cb78-44e2-b1d7-4bd75b516528.png)


SVA-475