### PR TITLE
fix(waste notifications): convert time to correct time zone

### DIFF
--- a/app/services/waste_notification.rb
+++ b/app/services/waste_notification.rb
@@ -35,7 +35,10 @@ class WasteNotification
         next if registration_to_check.blank?
         next if waste_pickup_time.blank?
 
-        date_time_to_run = DateTime.parse("#{check_date} #{registration_to_check.notify_at_time}")
+        # this way we can convert times, that are given as winter because of `time` database field,
+        # which serves on first of january, to the local time zone to correct it to summertime
+        # if it is summer
+        date_time_to_run = Time.zone.parse("#{check_date} #{registration_to_check.notify_at.to_s(:time)}")
         p "Registration Found for Waste::LocationType: #{waste_pickup_time.waste_location_type.id}, #{registration_to_check.id} on #{waste_pickup_time.pickup_date}"
         p "Run at: #{date_time_to_run}"
 


### PR DESCRIPTION
- updated `date_time_to_run` to convert times, that are given as winter
  because of `time` database field, which serves on first of january,
  to the local time zone to correct it to summertime if it is summer

SVA-467

---

given 10:06 in summer to get a push.

old result, which is 09:06 utc and 11:06 in summer:

```
DateTime.parse("#{check_date} #{registration_to_check.notify_at_time}")
=> Wed, 04 May 2022 09:06:00 +0000
```

new result, which is 08:06 utc and 10:06 in summer:

```
Time.zone.parse("#{check_date} #{registration_to_check.notify_at.to_s(:time)}")
=> Wed, 04 May 2022 10:06:00 CEST +02:00
```