### PR TITLE
fix: larger db field for unique_id in external_references

### DIFF
--- a/db/migrate/20220511120447_larger_unique_id_in_external_references.rb
+++ b/db/migrate/20220511120447_larger_unique_id_in_external_references.rb
@@ -1,0 +1,5 @@
+class LargerUniqueIdInExternalReferences < ActiveRecord::Migration[5.2]
+  def change
+    change_column :external_references, :unique_id, :text
+  end
+end


### PR DESCRIPTION
current field in db is to short and results to import errors