### PR TITLE
Absicherung der Default Kategorien

### DIFF
--- a/app/services/category_service.rb
+++ b/app/services/category_service.rb
@@ -1,0 +1,27 @@
+class CategoryService
+  def update_all_defaults
+    data_resource_types = DataResourceSetting::DATA_RESOURCES.map(&:to_s)
+    data_provider_ids = User.all.map(&:data_provider_id)
+
+    data_provider_ids.each do |data_provider_id|
+      data_resource_types.each do |data_resource_type|
+        set_defaults(data_resource_type: data_resource_type, data_provider_id: data_provider_id)
+      end
+    end
+  end
+
+  def set_defaults(data_resource_type:, data_provider_id:)
+    data_provider = DataProvider.find_by(id: data_provider_id)
+    return if data_provider.blank?
+
+    default_category_ids = data_provider.settings(data_resource_type).try(:default_category_ids)
+    return if default_category_ids.blank?
+
+    data_elements = data_provider.send(data_resource_type.underscore.pluralize)
+    data_elements.each do |data_element|
+      category_ids_to_add = default_category_ids - data_element.category_ids
+      data_element.categories << Category.where(id: category_ids_to_add) if category_ids_to_add.present? && category_ids_to_add.any?
+    end
+  end
+
+end

--- a/bin/start-cron.sh
+++ b/bin/start-cron.sh
@@ -2,3 +2,4 @@
 
 bundle exec rails runner "WasteNotification.new.send_notifications"
 bundle exec rails runner "CleanUpService.new.perform"
+bundle exec rails runner "CategoryService.new.update_all_defaults"

--- a/lib/tasks/batch_defaults.rake
+++ b/lib/tasks/batch_defaults.rake
@@ -7,18 +7,9 @@ namespace :batch_defaults do
     raise "data_resource_type does not exist" unless DataResourceSetting::DATA_RESOURCES.map(&:to_s).include?(data_resource_type)
 
     data_provider_id = ENV["DATAPROVIDER_ID"]
-    data_provider = DataProvider.find_by(id: data_provider_id)
-    raise "data_provider does not exist" if data_provider.blank?
 
     puts "Running batch action with data_provider_id #{data_provider_id} and data_resource_type #{data_resource_type}"
-
-    default_category_ids = data_provider.settings(data_resource_type).try(:default_category_ids)
-    raise "No default categories defined" if default_category_ids.blank?
-
-    data_elements = data_provider.send(data_resource_type.underscore.pluralize)
-    data_elements.each do |data_element|
-      data_element.categories << Category.where(id: default_category_ids)
-    end
+    CategoryService.new.set_defaults(data_resource_type: data_resource_type, data_provider_id: data_provider_id)
 
     puts "#{data_elements.count} elements updated"
   end


### PR DESCRIPTION
Einmal am Tag wird nun ein Job gestartet, der für alle DataProvidern und alle DataResourceTypes
die Defaultwerte der Kategorien überprüft und fehlende setzt.

SVA-528