### PR TITLE
Distinct category assignment by batch action

### DIFF
--- a/app/services/category_service.rb
+++ b/app/services/category_service.rb
@@ -14,7 +14,7 @@ class CategoryService
     data_provider = DataProvider.find_by(id: data_provider_id)
     return if data_provider.blank?
 
-    default_category_ids = data_provider.settings(data_resource_type).try(:default_category_ids)
+    default_category_ids = data_provider.settings(data_resource_type).try(:default_category_ids).map(&:to_i)
     return if default_category_ids.blank?
 
     data_elements = data_provider.send(data_resource_type.underscore.pluralize)

--- a/db/migrate/20220525095902_cleanup_multiple_category_assignments.rb
+++ b/db/migrate/20220525095902_cleanup_multiple_category_assignments.rb
@@ -1,0 +1,17 @@
+class CleanupMultipleCategoryAssignments < ActiveRecord::Migration[5.2]
+  def up
+    grouped_resource_categories = DataResourceCategory.all.group_by { |a| [a.category_id, a.data_resource_type, a.data_resource_id]}
+    to_delete_ids = []
+    grouped_resource_categories.each do |_group, resource_categories|
+      next if resource_categories.count <= 1
+
+      resource_category_ids = resource_categories.map(&:id)
+      min_id = resource_category_ids.min
+      to_delete_ids << resource_category_ids - Array(min_id)
+    end
+    DataResourceCategory.where(id: to_delete_ids.flatten).delete_all if to_delete_ids.flatten.any?
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
- fixing compare string with int in Line 22
  `category_ids_to_add = default_category_ids - data_element.category_ids`
  ["1"] - [1] => ["1"]

- adding migration to cleanup once multiple category assignments 

SVA-610