### PR TITLE
Prüfung auf  bereits existierende WasteNotificationJobs

### DIFF
--- a/app/services/waste_notification.rb
+++ b/app/services/waste_notification.rb
@@ -42,6 +42,13 @@ class WasteNotification
         p "Registration Found for Waste::LocationType: #{waste_pickup_time.waste_location_type.id}, #{registration_to_check.id} on #{waste_pickup_time.pickup_date}"
         p "Run at: #{date_time_to_run}"
 
+        # Look for existing Notification
+        existing_notifications_count = Delayed::Backend::ActiveRecord::Job
+                                         .where("handler LIKE '%WasteNotificationJob%'")
+                                         .where("handler LIKE '%args:\n- #{registration_to_check.id}\n- #{waste_pickup_time.id}%'")
+                                         .count
+        next if existing_notifications_count.positive?
+
         # Send Notification
         WasteNotificationJob.delay(run_at: date_time_to_run).perform(registration_to_check.id, waste_pickup_time.id)
       end


### PR DESCRIPTION
Der WasteNotification Job wird einmal am Tag per Cronjob gestartet.
Sollte der Cronjob fehlerhaft sein und neustarten oder manuell gestartet werden, kann es passieren, dass der gleiche WasteNotificationJob mehrmals in die Warteschlange in DelajedJob geschrieben wird.

Diese Erweiterung prüft vorab, ob es bereits einen WasteNotificationJobs mit den identischen Parameter Argumenten gibt bevor er in die Warteschlange gelegt wird.
Hierbei ist egal wann die Benachrichtigung erfolgen soll. Lediglich die Userregistrierung und der Abfalltyp ist für die Prüfung relevant.

SVA-620

---

follow up for #335 