### PR TITLE
feat(news): add option to query multiple category ids

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
-    ffi (1.11.1)
+    ffi (1.15.5)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -539,4 +539,4 @@ RUBY VERSION
    ruby 2.6.8p205
 
 BUNDLED WITH
-   2.3.1
+   2.3.18

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -29,6 +29,7 @@ class Resolvers::NewsItemsSearch
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :excludeDataProviderIds, type: types[types.ID], with: :apply_exclude_data_provider_ids
   option :categoryId, type: types.ID, with: :apply_category_id
+  option :categoryIds, type: types[types.ID], with: :apply_category_ids
 
   def apply_limit(scope, value)
     scope.limit(value)
@@ -61,6 +62,7 @@ class Resolvers::NewsItemsSearch
   def apply_category_id(scope, value)
     scope.by_category(value)
   end
+  alias_method :apply_category_ids, :apply_category_id
 
   def apply_order_with_created_at_desc(scope)
     scope.order("created_at DESC")


### PR DESCRIPTION
Updated ffi gem to make it work with m1 mac and added an news search option to query for multiple categories per id, like we already implemented for attractions.

SVA-660