### PR TITLE
Prevent duplicate entries of pickuptimes

### DIFF
--- a/app/graphql/mutations/create_waste_pick_up_time.rb
+++ b/app/graphql/mutations/create_waste_pick_up_time.rb
@@ -20,7 +20,7 @@ module Mutations
       address = Address.joins(:waste_location_types).where(waste_location_type_attributes[:address_attributes]).first_or_create
       waste_location_type = Waste::LocationType.where(address_id: address.id, waste_type: waste_location_type_attributes[:waste_type] ).first_or_create
 
-      Waste::PickUpTime.create(params.merge(waste_location_type_id: waste_location_type.id))
+      Waste::PickUpTime.where(params.merge(waste_location_type_id: waste_location_type.id)).first_or_create
     end
   end
 end


### PR DESCRIPTION
Allow an api importer to run multiple times without resulting in duplicate waste pickup times. Only create a pickuptime for an waste_location_type only once, if the params are identical.

![Bildschirm­foto 2022-11-16 um 12 10 44](https://user-images.githubusercontent.com/90779/202165917-e77f0a58-7ace-45e5-aa46-6cb8453df232.png)
=> Resending the Query now returns always the same ID instead of a new one

SVA-803