### PR TITLE
feat: cleanup notification devices

### DIFF
--- a/app/controllers/notification/devices_controller.rb
+++ b/app/controllers/notification/devices_controller.rb
@@ -121,7 +121,7 @@ class Notification::DevicesController < ApplicationController
 
     # Use callbacks to share common setup or constraints between actions.
     def set_notification_device
-      token = notification_device_params[:token]
+      token = notification_device_params[:token] if params[:notification_device].present?
       @notification_device = Notification::Device.find_by(token: token) and return if token.present?
       @notification_device = Notification::Device.find(params[:id]) if params[:id].present?
     end

--- a/app/jobs/send_single_push_notification_job.rb
+++ b/app/jobs/send_single_push_notification_job.rb
@@ -19,9 +19,30 @@ class SendSinglePushNotificationJob < ApplicationJob
 
     begin
       feedback = client.send_messages(messages)
-      RedisAdapter.add_push_log(device_token, message_options.merge(date: DateTime.now, payload: feedback.try(:response).try(:body)))
-    rescue => e
-      RedisAdapter.add_push_log(device_token, message_options.merge(rescue_error: "push notification", error: e, date: DateTime.now))
+      payload = feedback.try(:response).try(:body)
+
+      RedisAdapter.add_push_log(
+        device_token,
+        message_options.merge(date: DateTime.now, payload: payload)
+      )
+
+      cleanup_if_unregistered_device(device_token, payload)
+    rescue StandardError => e
+      RedisAdapter.add_push_log(
+        device_token,
+        message_options.merge(rescue_error: "push notification", error: e, date: DateTime.now)
+      )
     end
+  end
+
+  def cleanup_if_unregistered_device(device_token, payload)
+    return if payload.blank?
+    return if payload["data"].blank?
+    return unless payload["data"]["status"] == "error"
+    return unless payload["data"]["message"] == "The recipient device is not registered with FCM."
+    return if payload["data"]["details"].blank?
+    return unless payload["data"]["details"]["error"] == "DeviceNotRegistered"
+
+    Notification::Device.where(token: device_token).destroy_all
   end
 end

--- a/app/models/data_resources/news_item.rb
+++ b/app/models/data_resources/news_item.rb
@@ -105,7 +105,7 @@ class NewsItem < ApplicationRecord
         }
       }
 
-      PushNotification.delay.send_notifications(options) if Rails.env.production?
+      PushNotification.delay.send_notifications(options)
 
       touch(:push_notifications_sent_at)
     end

--- a/app/services/push_notification.rb
+++ b/app/services/push_notification.rb
@@ -11,7 +11,7 @@
 # }
 class PushNotification
   def self.send_notification(device, message_options = {})
-    SendSinglePushNotificationJob.perform_later(device.token, message_options)
+    SendSinglePushNotificationJob.perform_later(device.token, message_options) if Rails.env.production?
   end
 
   def self.send_notifications(message_options = {})


### PR DESCRIPTION
- added cleanup if push notification was tried to sent to unregistered device
- fixed check for `notification_device` in params for `set_notification_device` because navigating in the backend to a device failed
- refactored waste notifications sending of pushs to reduce repetitions
- moved `if Rails.env.production?` entirely in `send_notification` instead of having it at several places, because we do not want to process push notifications in development mode (or others)

SVA-816