### PR TITLE
feat(push notifications): create model for storing timings, connect to generic items and create mutation to schedule

### DIFF
--- a/app/graphql/mutations/schedule_push_notification.rb
+++ b/app/graphql/mutations/schedule_push_notification.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Mutations
+  class SchedulePushNotification < BaseMutation
+    argument :notification_pushable_type, String, required: true
+    argument :notification_pushable_id, Integer, required: true
+    argument :once_at, String, required: false
+    argument :monday_at, String, required: false
+    argument :tuesday_at, String, required: false
+    argument :wednesday_at, String, required: false
+    argument :thursday_at, String, required: false
+    argument :friday_at, String, required: false
+    argument :saturday_at, String, required: false
+    argument :sunday_at, String, required: false
+    argument :recurring, Integer, required: false
+    argument :title, String, required: true
+    argument :body, String, required: false
+    argument :data, Types::InputTypes::PushNotificationDataInput, required: false
+    argument :force_create, Boolean, required: false
+
+    type Types::StatusType
+
+    RECORD_WHITELIST = [
+      "EventRecord",
+      "GenericItem",
+      "NewsItem",
+      "PointOfInterest",
+      "Tour"
+    ].freeze
+
+    def resolve(**params)
+      raise "Access not permitted" unless roles[:role_push_notification] == true
+      return GraphQL::ExecutionError.new("Request not valid") unless valid?(params)
+
+      push_notification = Notification::Push.create(params)
+
+      unless push_notification.valid?
+        return GraphQL::ExecutionError.new(
+          "Request not valid: #{push_notification.errors.full_messages.join(", ")}"
+        )
+      end
+
+      OpenStruct.new(
+        id: push_notification.id,
+        status: "Push notifications successfully scheduled",
+        status_code: 200
+      )
+    end
+
+    private
+
+      def roles
+        context[:current_user].try(:data_provider).try(:roles) || {}
+      end
+
+      def valid?(params)
+        RECORD_WHITELIST.include?(params[:notification_pushable_type]) &&
+          params[:notification_pushable_type].present? &&
+          params[:notification_pushable_id].present? &&
+          params[:recurring].present? && (
+            (params[:recurring].to_i.zero? && params[:once_at].present?) ||
+            params[:recurring].to_i.positive?
+          ) &&
+          params[:title].present?
+      end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -17,6 +17,7 @@ module Types
     field :create_or_update_survey_poll, mutation: Mutations::CreateOrUpdateSurveyPoll
     field :create_or_update_static_content, mutation: Mutations::CreateOrUpdateStaticContent
     field :send_push_notification, mutation: Mutations::SendPushNotification
+    field :schedule_push_notification, mutation: Mutations::SchedulePushNotification
     field :create_generic_item_message, mutation: Mutations::CreateGenericItemMessage
 
     # destroys

--- a/app/graphql/types/query_types/generic_item_type.rb
+++ b/app/graphql/types/query_types/generic_item_type.rb
@@ -22,6 +22,7 @@ module Types
     field :price_informations, [QueryTypes::PriceType], null: true
     field :publication_date, String, null: true
     field :published_at, String, null: true
+    field :push_notifications, [QueryTypes::PushNotificationType], null: true
     field :settings, QueryTypes::SettingType, null: true
     field :title, String, null: true
     field :visible, Boolean, null: true

--- a/app/graphql/types/query_types/push_notification_data_type.rb
+++ b/app/graphql/types/query_types/push_notification_data_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class QueryTypes::PushNotificationDataType < Types::BaseObject
+    field :id, ID, null: true
+    field :query_type, String, null: true
+    field :data_provider_id, ID, null: true
+  end
+end

--- a/app/graphql/types/query_types/push_notification_type.rb
+++ b/app/graphql/types/query_types/push_notification_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  class QueryTypes::PushNotificationType < Types::BaseObject
+    field :notification_pushable_type, String, null: false
+    field :notification_pushable_id, Integer, null: false
+    field :once_at, String, null: true
+    field :monday_at, String, null: true
+    field :tuesday_at, String, null: true
+    field :wednesday_at, String, null: true
+    field :thursday_at, String, null: true
+    field :friday_at, String, null: true
+    field :saturday_at, String, null: true
+    field :sunday_at, String, null: true
+    field :recurring, Integer, null: true
+    field :title, String, null: false
+    field :body, String, null: true
+    field :data, QueryTypes::PushNotificationDataType, null: true
+  end
+end

--- a/app/models/data_resources/generic_item.rb
+++ b/app/models/data_resources/generic_item.rb
@@ -1,5 +1,6 @@
 class GenericItem < ApplicationRecord
   include FilterByRole
+
   has_ancestry orphan_strategy: :destroy
 
   GENERIC_TYPES = {
@@ -34,6 +35,10 @@ class GenericItem < ApplicationRecord
   has_many :price_informations, as: :priceable, class_name: "Price", dependent: :destroy
   has_many :web_urls, as: :web_urlable, dependent: :destroy
   has_many :messages, class_name: "GenericItem::Message", dependent: :destroy
+  has_many :push_notifications,
+           as: :notification_pushable,
+           class_name: "Notification::Push",
+           dependent: :destroy
 
   # defined by FilterByRole
   # scope :visible, -> { where(visible: true) }
@@ -50,7 +55,7 @@ class GenericItem < ApplicationRecord
   accepts_nested_attributes_for :web_urls, reject_if: ->(attr) { attr[:url].blank? }
   accepts_nested_attributes_for :content_blocks, :data_provider, :price_informations, :opening_hours,
                                 :media_contents, :accessibility_informations, :addresses, :contacts,
-                                :companies, :locations, :dates
+                                :companies, :locations, :dates, :push_notifications
 
   def generic_items
     children

--- a/app/models/notification/push.rb
+++ b/app/models/notification/push.rb
@@ -3,6 +3,13 @@
 class Notification::Push < ApplicationRecord
   belongs_to :notification_pushable, polymorphic: true
 
+  store :data,
+        accessors: %i[
+          id
+          query_type
+          data_provider_id
+        ], coder: JSON
+
   def recurring_count
     return 0 unless recurring
 
@@ -37,4 +44,7 @@ end
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  recurring                  :integer          default(0)
+#  title                      :string(255)
+#  body                       :string(255)
+#  data                       :text(65535)
 #

--- a/app/models/notification/push.rb
+++ b/app/models/notification/push.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Notification::Push < ApplicationRecord
+  belongs_to :notification_pushable, polymorphic: true
+
+  def recurring_count
+    return 0 unless is_recurring
+
+    # filter present weekday fields and count them
+    [
+      monday_at,
+      tuesday_at,
+      wednesday_at,
+      thursday_at,
+      friday_at,
+      saturday_at,
+      sunday_at
+    ].compact.delete_if(&:blank?).count
+  end
+end
+
+# == Schema Information
+#
+# Table name: notification_pushes
+#
+#  id                         :bigint           not null, primary key
+#  notification_pushable_type :string(255)
+#  notification_pushable_id   :integer
+#  once_at                    :datetime
+#  is_recurring               :boolean          default(FALSE)
+#  monday_at                  :time
+#  tuesday_at                 :time
+#  wednesday_at               :time
+#  thursday_at                :time
+#  friday_at                  :time
+#  saturday_at                :time
+#  sunday_at                  :time
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#

--- a/app/models/notification/push.rb
+++ b/app/models/notification/push.rb
@@ -10,6 +10,8 @@ class Notification::Push < ApplicationRecord
           data_provider_id
         ], coder: JSON
 
+  attr_accessor :force_create
+
   validates :recurring_count,
             numericality: { greater_than: 0 },
             if: ->(item) { item.recurring.positive? }

--- a/app/models/notification/push.rb
+++ b/app/models/notification/push.rb
@@ -10,8 +10,12 @@ class Notification::Push < ApplicationRecord
           data_provider_id
         ], coder: JSON
 
+  validates :recurring_count,
+            numericality: { greater_than: 0 },
+            if: ->(item) { item.recurring.positive? }
+
   def recurring_count
-    return 0 unless recurring
+    return 0 unless recurring.positive?
 
     # filter present weekday fields and count them
     [

--- a/app/models/notification/push.rb
+++ b/app/models/notification/push.rb
@@ -4,7 +4,7 @@ class Notification::Push < ApplicationRecord
   belongs_to :notification_pushable, polymorphic: true
 
   def recurring_count
-    return 0 unless is_recurring
+    return 0 unless recurring
 
     # filter present weekday fields and count them
     [
@@ -25,9 +25,8 @@ end
 #
 #  id                         :bigint           not null, primary key
 #  notification_pushable_type :string(255)
-#  notification_pushable_id   :integer
+#  notification_pushable_id   :bigint
 #  once_at                    :datetime
-#  is_recurring               :boolean          default(FALSE)
 #  monday_at                  :time
 #  tuesday_at                 :time
 #  wednesday_at               :time
@@ -37,4 +36,5 @@ end
 #  sunday_at                  :time
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
+#  recurring                  :integer          default(0)
 #

--- a/app/services/push_notification.rb
+++ b/app/services/push_notification.rb
@@ -11,7 +11,9 @@
 # }
 class PushNotification
   def self.send_notification(device, message_options = {})
-    SendSinglePushNotificationJob.perform_later(device.token, message_options) if Rails.env.production?
+    return unless Rails.env.production?
+
+    SendSinglePushNotificationJob.perform_later(device.token, message_options)
   end
 
   def self.send_notifications(message_options = {})
@@ -28,5 +30,40 @@ class PushNotification
     notification_devices.each do |device|
       send_notification(device, message_options)
     end
+  end
+
+  def schedule_notifications
+    check_date = Date.today
+    notification_pushes = Notification::Push.all
+
+    notification_pushes.each do |notification_push|
+      if notification_push.recurring.zero? && notification_push.once_at.present?
+        # if a push notification should be sent once today at a certain time
+        next unless check_date.to_s(:date) == notification_push.once_at.strftime("%Y-%m-%d")
+
+        time_to_run = notification_push.once_at.to_s(:time)
+      else
+        # if a push notification should be sent on todays weekday at a certain time
+        check_weekday = check_date.strftime("%A").downcase
+        weekday_method = "#{check_weekday}_at".to_sym
+
+        next unless notification_push.methods.include?(weekday_method)
+
+        time_to_run = notification_push.send(weekday_method).to_s(:time)
+      end
+
+      # this way we can convert times, that are given as winter because of `time` database field,
+      # which serves on first of january, to the local time zone to correct it to summertime
+      # if it is summer
+      date_time_to_run = Time.zone.parse("#{check_date} #{time_to_run}")
+      p "Push notification found for: #{notification_push.notification_pushable_type} ##{notification_push.notification_pushable_id}"
+      p "Scheduled at: #{date_time_to_run}"
+
+      next unless Rails.env.production?
+
+      SendSinglePushNotificationJob.delay(run_at: date_time_to_run).perform(device.token, message_options)
+    end
+
+    "Notifications scheduled for today"
   end
 end

--- a/bin/start-cron.sh
+++ b/bin/start-cron.sh
@@ -3,3 +3,4 @@
 bundle exec rails runner "WasteNotification.new.send_notifications"
 bundle exec rails runner "CleanUpService.new.perform"
 bundle exec rails runner "CategoryService.new.update_all_defaults"
+bundle exec rails runner "PushNotification.new.schedule_notifications"

--- a/db/migrate/20221125161012_create_notification_pushes.rb
+++ b/db/migrate/20221125161012_create_notification_pushes.rb
@@ -4,7 +4,7 @@ class CreateNotificationPushes < ActiveRecord::Migration[5.2]
   def change
     create_table :notification_pushes do |t|
       t.string :notification_pushable_type
-      t.integer :notification_pushable_id
+      t.bigint :notification_pushable_id
       t.datetime :once_at
       t.boolean :is_recurring, default: false
       t.time :monday_at

--- a/db/migrate/20221125161012_create_notification_pushes.rb
+++ b/db/migrate/20221125161012_create_notification_pushes.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateNotificationPushes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :notification_pushes do |t|
+      t.string :notification_pushable_type
+      t.integer :notification_pushable_id
+      t.datetime :once_at
+      t.boolean :is_recurring, default: false
+      t.time :monday_at
+      t.time :tuesday_at
+      t.time :wednesday_at
+      t.time :thursday_at
+      t.time :friday_at
+      t.time :saturday_at
+      t.time :sunday_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221128112410_change_is_recurring_to_integer.rb
+++ b/db/migrate/20221128112410_change_is_recurring_to_integer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ChangeIsRecurringToInteger < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :notification_pushes, :is_recurring
+    add_column :notification_pushes, :recurring, :integer, default: 0
+  end
+
+  def down
+    remove_column :notification_pushes, :recurring
+    add_column :notification_pushes, :is_recurring, :boolean, default: 0
+  end
+end

--- a/db/migrate/20221128115505_add_content_fields_for_notification_pushes.rb
+++ b/db/migrate/20221128115505_add_content_fields_for_notification_pushes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddContentFieldsForNotificationPushes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :notification_pushes, :title, :string
+    add_column :notification_pushes, :body, :string
+    add_column :notification_pushes, :data, :text
+  end
+end

--- a/spec/factories/generic_items.rb
+++ b/spec/factories/generic_items.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :generic_item do
+    id { 1 }
+    title { "MyString" }
+    description { "MyText" }
+  end
+end
+
+# == Schema Information
+#
+# Table name: generic_items
+#
+#  id               :bigint           not null, primary key
+#  generic_type     :string(255)
+#  author           :text(65535)
+#  publication_date :datetime
+#  published_at     :datetime
+#  external_id      :text(65535)
+#  visible          :boolean          default(TRUE)
+#  title            :text(65535)
+#  teaser           :text(65535)
+#  description      :text(65535)
+#  data_provider_id :integer
+#  payload          :text(65535)
+#  ancestry         :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#

--- a/spec/factories/notification_pushes.rb
+++ b/spec/factories/notification_pushes.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :notification_push_once, class: "Notification::Push" do
+    id { 1 }
+    notification_pushable_type { "GenericItem" }
+    notification_pushable_id { 1 }
+    once_at { "2022-11-25 17:00:00" }
+    is_recurring { false }
+    monday_at { nil }
+    tuesday_at { nil }
+    wednesday_at { nil }
+    thursday_at { nil }
+    friday_at { nil }
+    saturday_at { nil }
+    sunday_at { nil }
+  end
+
+  factory :notification_push_mondays, class: "Notification::Push" do
+    id { 2 }
+    notification_pushable_type { "GenericItem" }
+    notification_pushable_id { 2 }
+    once_at { nil }
+    is_recurring { true }
+    monday_at { "12:00:00" }
+    tuesday_at { nil }
+    wednesday_at { nil }
+    thursday_at { nil }
+    friday_at { nil }
+    saturday_at { nil }
+    sunday_at { nil }
+  end
+
+  factory :notification_push_wednesdays_and_saturdays, class: "Notification::Push" do
+    id { 3 }
+    notification_pushable_type { "GenericItem" }
+    notification_pushable_id { 3 }
+    once_at { nil }
+    is_recurring { true }
+    monday_at { nil }
+    tuesday_at { nil }
+    wednesday_at { "14:00:00" }
+    thursday_at { nil }
+    friday_at { nil }
+    saturday_at { "14:00:00" }
+    sunday_at { nil }
+  end
+end
+
+# == Schema Information
+#
+# Table name: notification_pushes
+#
+#  id                         :bigint           not null, primary key
+#  notification_pushable_type :string(255)
+#  notification_pushable_id   :integer
+#  once_at                    :datetime
+#  is_recurring               :boolean          default(FALSE)
+#  monday_at                  :time
+#  tuesday_at                 :time
+#  wednesday_at               :time
+#  thursday_at                :time
+#  friday_at                  :time
+#  saturday_at                :time
+#  sunday_at                  :time
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#

--- a/spec/factories/notification_pushes.rb
+++ b/spec/factories/notification_pushes.rb
@@ -65,4 +65,7 @@ end
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  recurring                  :integer          default(0)
+#  title                      :string(255)
+#  body                       :string(255)
+#  data                       :text(65535)
 #

--- a/spec/factories/notification_pushes.rb
+++ b/spec/factories/notification_pushes.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     notification_pushable_type { "GenericItem" }
     notification_pushable_id { 1 }
     once_at { "2022-11-25 17:00:00" }
-    is_recurring { false }
+    recurring { 0 }
     monday_at { nil }
     tuesday_at { nil }
     wednesday_at { nil }
@@ -21,7 +21,7 @@ FactoryBot.define do
     notification_pushable_type { "GenericItem" }
     notification_pushable_id { 2 }
     once_at { nil }
-    is_recurring { true }
+    recurring { 1 }
     monday_at { "12:00:00" }
     tuesday_at { nil }
     wednesday_at { nil }
@@ -36,7 +36,7 @@ FactoryBot.define do
     notification_pushable_type { "GenericItem" }
     notification_pushable_id { 3 }
     once_at { nil }
-    is_recurring { true }
+    recurring { 1 }
     monday_at { nil }
     tuesday_at { nil }
     wednesday_at { "14:00:00" }
@@ -53,9 +53,8 @@ end
 #
 #  id                         :bigint           not null, primary key
 #  notification_pushable_type :string(255)
-#  notification_pushable_id   :integer
+#  notification_pushable_id   :bigint
 #  once_at                    :datetime
-#  is_recurring               :boolean          default(FALSE)
 #  monday_at                  :time
 #  tuesday_at                 :time
 #  wednesday_at               :time
@@ -65,4 +64,5 @@ end
 #  sunday_at                  :time
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
+#  recurring                  :integer          default(0)
 #

--- a/spec/graphql/mutations/schedule_push_notification_spec.rb
+++ b/spec/graphql/mutations/schedule_push_notification_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Mutations::SchedulePushNotification do
+  def perform(**args)
+    user = create(:user)
+    data_provider = create(:data_provider, roles: { role_push_notification: true })
+    user.data_provider = data_provider
+    user.save
+
+    Mutations::SchedulePushNotification.new(
+      object: nil,
+      field: nil,
+      context: { current_user: user }
+    ).resolve(args)
+  end
+
+  describe "once" do
+    it "successfully schedules a push notification" do
+      push_notification = perform(
+        notification_pushable_type: "GenericItem",
+        notification_pushable_id: 1,
+        once_at: "2022-12-24 12:00:00",
+        recurring: 0,
+        title: "Title",
+        body: "Body"
+      )
+
+      expect(push_notification.status_code).to be(200)
+    end
+
+    it "fails scheduling a one time push notification with bad type" do
+      push_notification = perform(
+        notification_pushable_type: "BadType",
+        notification_pushable_id: 1,
+        once_at: "2022-12-24 12:00:00",
+        recurring: 0,
+        title: "Title",
+        body: "Body"
+      )
+
+      expect(push_notification.message).to eq("Request not valid")
+    end
+  end
+
+  describe "recurring" do
+    it "successfully schedules a recurring push notification" do
+      push_notification = perform(
+        notification_pushable_type: "GenericItem",
+        notification_pushable_id: 1,
+        recurring: 1,
+        monday_at: "14:00",
+        title: "Title",
+        body: "Body"
+      )
+
+      expect(push_notification.status_code).to be(200)
+    end
+
+    it "fails scheduling a recurring push notification with bad type" do
+      push_notification = perform(
+        notification_pushable_type: "BadType",
+        notification_pushable_id: 1,
+        recurring: 1,
+        monday_at: "14:00",
+        title: "Title",
+        body: "Body"
+      )
+
+      expect(push_notification.message).to eq("Request not valid")
+    end
+
+    it "fails scheduling a recurring push notification" do
+      push_notification = perform(
+        notification_pushable_type: "GenericItem",
+        notification_pushable_id: 1,
+        recurring: 1,
+        title: "Title",
+        body: "Body"
+      )
+
+      expect(push_notification.message).to eq("Request not valid: Recurring count must be greater than 0")
+    end
+  end
+end

--- a/spec/models/notification/push_spec.rb
+++ b/spec/models/notification/push_spec.rb
@@ -24,4 +24,13 @@ RSpec.describe Notification::Push, type: :model do
       expect(notification.recurring_count).to eq(2)
     end
   end
+
+  describe "belongs_to" do
+    it "generic item" do
+      notification = FactoryBot.build(:notification_push_once)
+      generic_item = FactoryBot.build(:generic_item, push_notifications: [notification])
+
+      expect(generic_item.push_notifications.to_a.size).to eq(1)
+    end
+  end
 end

--- a/spec/models/notification/push_spec.rb
+++ b/spec/models/notification/push_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Notification::Push, type: :model do
+  it { is_expected.to belong_to(:notification_pushable) }
+
+  describe "recurring_count" do
+    it "is 0 if once" do
+      notification = FactoryBot.build(:notification_push_once)
+
+      expect(notification.recurring_count).to eq(0)
+    end
+
+    it "is 1 if on one day" do
+      notification = FactoryBot.build(:notification_push_mondays)
+
+      expect(notification.recurring_count).to eq(1)
+    end
+
+    it "is 2 if on two days" do
+      notification = FactoryBot.build(:notification_push_wednesdays_and_saturdays)
+
+      expect(notification.recurring_count).to eq(2)
+    end
+  end
+end

--- a/spec/models/notification/push_spec.rb
+++ b/spec/models/notification/push_spec.rb
@@ -53,4 +53,7 @@ end
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  recurring                  :integer          default(0)
+#  title                      :string(255)
+#  body                       :string(255)
+#  data                       :text(65535)
 #

--- a/spec/models/notification/push_spec.rb
+++ b/spec/models/notification/push_spec.rb
@@ -34,3 +34,23 @@ RSpec.describe Notification::Push, type: :model do
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: notification_pushes
+#
+#  id                         :bigint           not null, primary key
+#  notification_pushable_type :string(255)
+#  notification_pushable_id   :bigint
+#  once_at                    :datetime
+#  monday_at                  :time
+#  tuesday_at                 :time
+#  wednesday_at               :time
+#  thursday_at                :time
+#  friday_at                  :time
+#  saturday_at                :time
+#  sunday_at                  :time
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  recurring                  :integer          default(0)
+#


### PR DESCRIPTION
This PR adds a new model that can store timings several configured timings for push notifications and adds a relation for generic items. This also extends with a mutation to schedule push notifications, which will be used by the CMS.
A last step is a new job, that checks for timings each day to delay push notifications that should take place once at a specific date and time or recurring on specific weekdays.

SVA-710