### PR TITLE
fix: URL Umschreibung nur noch nach create

### DIFF
--- a/app/models/data_resources/resource_modules/media_content.rb
+++ b/app/models/data_resources/resource_modules/media_content.rb
@@ -7,7 +7,7 @@ class MediaContent < ApplicationRecord
   has_one :source_url, as: :web_urlable, class_name: "WebUrl", dependent: :destroy
   has_one_attached :attachment
 
-  after_save :convert_source_url_to_external_storage
+  after_create :convert_source_url_to_external_storage
 
   validates_presence_of :content_type
 


### PR DESCRIPTION
Mir ist unklar warum, aber ein "attachment.attach" in Zeile 30 führt (neuerdings) zu einem save mit dem ausführen aller Callbacks. Dadurch entsteht eine Endlosschleife die nicht durchbrochen wird, da die Abbruchbedinnung erst in Zeile 35 zustandekommen würde.

Durch den Wechsel zu after_create statt after_save wird der Callback nun garantiert nur noch einmal gestartet.

eventueller Nachteil: Wenn nachträglich die URL eines MediaContents nun verändert wird wieder zu einer neuen Source-URL würde diese nicht erneut in das eigene MinIO importiert werden. Es bleibt dann bei der neuen Source-URL.