### PR TITLE
feat(defect report): add media content upload

### DIFF
--- a/app/controllers/media_contents_controller.rb
+++ b/app/controllers/media_contents_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class MediaContentsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  before_action :auth_user_or_doorkeeper
+
+  # POST /media_contents.json
+  def create
+    media_content = MediaContent.new(media_content_params)
+
+    respond_to do |format|
+      if media_content.save
+        format.json do
+          render json: {
+            media_content: media_content,
+            service_url: media_content.attachment.service_url.sub(/\?.*/, "")
+          }, status: :created
+        end
+      else
+        format.json { render json: media_content.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+    def auth_user_or_doorkeeper
+      raise "unauthorized" if current_user.present? && !current_user.admin_role?
+
+      doorkeeper_authorize! if current_user.blank?
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def media_content_params
+      params.require(:media_content).permit(:attachment, :content_type)
+    end
+
+end

--- a/app/mailers/defect_report_mailer.rb
+++ b/app/mailers/defect_report_mailer.rb
@@ -13,7 +13,7 @@ class DefectReportMailer < ApplicationMailer
 
     return unless valid_for_notify_for_category?
 
-    @image_url = generic_item.media_contents.try(:first).try(:sourceUrl).try(:url)
+    @image_url = generic_item.media_contents.try(:first).try(:source_url).try(:url)
 
     @address = generic_item.addresses.try(:first)
 
@@ -28,12 +28,12 @@ class DefectReportMailer < ApplicationMailer
       @map_link = "https://www.openstreetmap.org/?mlat=#{lat}&mlon=#{lon}" if lat && lon
     end
 
-    @creator = generic_item.contacts.try(:first)
+    creator = generic_item.contacts.try(:first)
 
-    if @creator
-      @name = @creator.first_name
-      @email = @creator.email
-      @phone = @creator.phone
+    if creator.present?
+      @name = creator.first_name
+      @email = creator.email
+      @phone = creator.phone
     end
 
     mail(

--- a/app/models/data_resources/resource_modules/media_content.rb
+++ b/app/models/data_resources/resource_modules/media_content.rb
@@ -3,7 +3,7 @@
 # This model provides media content of various types to any other resource who
 # needs one or more media contents.
 class MediaContent < ApplicationRecord
-  belongs_to :mediaable, polymorphic: true
+  belongs_to :mediaable, polymorphic: true, optional: true
   has_one :source_url, as: :web_urlable, class_name: "WebUrl", dependent: :destroy
   has_one_attached :attachment
 

--- a/app/views/mailers/defect_report/notify_for_category.text.erb
+++ b/app/views/mailers/defect_report/notify_for_category.text.erb
@@ -16,7 +16,7 @@ Adresse: <%= @location %>
 <%- if @map_link %>
 Auf Karte: <%= @map_link %>
 <% end -%>
-<%- if @creator %>
+<%- if @name || @email || @phone %>
 
 Meldung erstellt von:
 <%- if @name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :categories
   resources :app_user_contents
   resources :static_contents
+  resources :media_contents, only: %i[create], defaults: { format: "json" }
   get "data_provider", to: "data_provider#show", as: :data_provider
   get "data_provider/edit", as: :edit_data_provider
   post "data_provider/update", as: :update_data_provider

--- a/spec/mailers/previews/defect_report_mailer_preview.rb
+++ b/spec/mailers/previews/defect_report_mailer_preview.rb
@@ -29,7 +29,7 @@ class DefectReportMailerPreview < ActionMailer::Preview
     generic_item.contacts = [OpenStruct.new(first_name: "Tim Test", email: "tim.test@smart-village.app", phone: "0123456789")]
     generic_item.categories = [OpenStruct.new(name: "Abfall/Müll", contact: OpenStruct.new(email: "tom.tast@smart-village.app"))]
     generic_item.content_blocks = [OpenStruct.new(body: "Test mit mehr Worten", title: "Test")]
-    generic_item.media_contents = [OpenStruct.new(sourceUrl: OpenStruct.new(url: "https://fileserver.smart-village.app/herzberg-elster/ehrenamt/service-kalender.png"), content_type: "image")]
+    generic_item.media_contents = [OpenStruct.new(source_url: OpenStruct.new(url: "https://fileserver.smart-village.app/herzberg-elster/ehrenamt/service-kalender.png"), content_type: "image")]
     generic_item.addresses = [OpenStruct.new(street: "Straße", zip: "03443", city: "Stadt", geo_location: OpenStruct.new(latitude: 50.1212, longitude: 13.3434))]
     generic_item.external_reference = OpenStruct.new(unique_id: "1234567890")
 


### PR DESCRIPTION
- added routed to create media content uploads with ``` media_content[attachment] = "/example/file.png" media_content[content_type] = "image" ``` as `POST` to: `/media_contents`
  - returns the media content and the service url as json - copied `service_url` from `convert_source_url_to_external_storage`

SVA-738