### PR TITLE
Speed up events query

### DIFF
--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -63,11 +63,9 @@ class EventRecord < ApplicationRecord
                       EventRecord.all
                     end
 
-    upcoming_event_record_ids = event_records.select do |event_record|
-      event_record.list_date.try(:to_time).to_i >= Date.today.to_time.to_i
-    end.map(&:id)
-
-    where(id: upcoming_event_record_ids)
+    event_records
+      .joins(:dates)
+      .where("fixed_dates.date_start >= ? OR fixed_dates.date_end >= ?", Date.today, Date.today)
   }
 
   scope :by_category, lambda { |category_id|


### PR DESCRIPTION
Use sql to get events where date_start or date_end is in the future instead of calling the method :list_date on each event_record

SVA-819

